### PR TITLE
Logout button/ fix icon

### DIFF
--- a/src/MenuPage/MenuPage.js
+++ b/src/MenuPage/MenuPage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { useQuery } from '@apollo/client'
 import { MENU_QUERY } from './MENU_QUERY'
 import PropTypes from 'prop-types'
@@ -12,6 +12,8 @@ import { Link } from 'react-router-dom'
 import { MenuDrawer } from 'shared/MenuDrawer'
 import { Container } from 'shared/Container'
 import { Spinner } from 'shared/Spinner'
+import { CurrentUserContext } from '../CurrentUserContextProvider'
+import { SignInOrOutButton } from './SignInOrOutButton'
 
 const Wrapper = styled.div`
   display: flex;
@@ -23,15 +25,25 @@ const Wrapper = styled.div`
 `
 
 export const MenuPage = ({ id }) => {
+  const { userData } = useContext(CurrentUserContext)
+
   const { data, loading } = useQuery(MENU_QUERY, { variables: { id } })
-  if (loading) return <Spinner />
+  if (loading)
+    return (
+      <Layout backgroundColor={colors.primary}>
+        <Spinner />
+      </Layout>
+    )
   const menu = mapMenu(data.menu)
+
+  const showMenuButton =
+    userData && userData.signedInUser.type === 'admin' ? true : false
+
+  const showLogoutButton = userData && userData.signedInUser.type
 
   return (
     <Layout backgroundColor={colors.primary}>
-      <HeaderWrapper>
-        <MenuDrawer />
-      </HeaderWrapper>
+      <HeaderWrapper>{showMenuButton && <MenuDrawer />}</HeaderWrapper>
       <Container>
         <Wrapper>
           {menu.elements.map(({ initials, lessonId }) => (
@@ -43,6 +55,7 @@ export const MenuPage = ({ id }) => {
             </Link>
           ))}
         </Wrapper>
+        <SignInOrOutButton showLogoutButton={showLogoutButton} />
       </Container>
     </Layout>
   )

--- a/src/MenuPage/SignInOrOutButton.js
+++ b/src/MenuPage/SignInOrOutButton.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { LogoutButton } from 'shared/LogoutButton'
+import styled from 'styled-components'
+import { colors } from 'shared/colors'
+import { useHistory } from 'react-router-dom'
+
+const SignInOrOutButtonWrapper = styled.div`
+  color: ${colors.white};
+  position: fixed;
+  text-align: center;
+  bottom: 20px;
+  left: calc(50% - 80px);
+  min-width: 80px;
+  border: solid 1px ${colors.white};
+  border-radius: 7px;
+  :hover {
+    cursor: pointer;
+  }
+`
+const SignInButton = styled.div`
+  padding-top: 12px;
+  padding-bottom: 12px;
+`
+
+export const SignInOrOutButton = ({ showLogoutButton }) => {
+  let history = useHistory()
+  const navigateToSignin = () => {
+    history.push('/signin')
+  }
+  return (
+    <>
+      <SignInOrOutButtonWrapper>
+        {showLogoutButton ? (
+          <LogoutButton />
+        ) : (
+          <SignInButton onClick={navigateToSignin}>Entrar</SignInButton>
+        )}
+      </SignInOrOutButtonWrapper>
+    </>
+  )
+}
+
+SignInOrOutButton.propTypes = {
+  showLogoutButton: PropTypes.bool,
+}

--- a/src/SignInPage/SignInForm.js
+++ b/src/SignInPage/SignInForm.js
@@ -38,6 +38,7 @@ export const SignInForm = () => {
     if (data) {
       saveTokens(data.signIn)
       navigateToMenu()
+      history.go(0)
     }
   }
 

--- a/src/ViewLessonPage/Lesson.js
+++ b/src/ViewLessonPage/Lesson.js
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useContext } from 'react'
+import { CurrentUserContext } from '../CurrentUserContextProvider'
 import { useQuery } from '@apollo/client'
 import { useParams } from 'react-router-dom'
 import { Layout } from 'shared/Layout'
@@ -6,19 +7,23 @@ import { Container } from 'shared/Container'
 import { HeaderWrapper } from 'shared/HeaderWrapper'
 import { ViewableElements } from './ViewableElements/ViewableElements'
 import { LESSON_QUERY } from 'shared/LESSON_QUERY'
-import { LessonItem } from 'shared/LessonItem'
+import { LessonItem } from './LessonItem'
 import { Link } from 'react-router-dom'
 import { MenuDrawer } from 'shared/MenuDrawer'
 import PropTypes from 'prop-types'
 
 export const Lesson = ({ initials, menuId }) => {
+  const { userData } = useContext(CurrentUserContext)
+  const showMenuButton =
+    userData && userData.signedInUser.type === 'admin' ? true : false
+
   const { lesson } = useParams()
   const { data } = useQuery(LESSON_QUERY, { variables: { id: lesson } })
 
   return data ? (
     <Layout>
       <HeaderWrapper>
-        <MenuDrawer />
+        {showMenuButton && <MenuDrawer />}
         <Link to={`/viewMenu/${menuId}`}>
           <LessonItem initials={initials} />
         </Link>

--- a/src/ViewLessonPage/LessonItem.js
+++ b/src/ViewLessonPage/LessonItem.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { colors } from 'shared/colors'
+
+const Wrapper = styled.div`
+  background-color: ${colors.white};
+  margin: 10px;
+  border: solid 1px #999;
+  color: #655;
+  border-radius: 5px;
+  min-width: 3rem;
+  min-height: 3rem;
+  width: 3rem;
+  height: 3rem;
+  font-size: 3rem;
+  text-align: center;
+  font-family: Karla;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+`
+
+export const LessonItem = ({ initials }) => {
+  return <Wrapper>{initials}</Wrapper>
+}
+
+LessonItem.propTypes = {
+  initials: PropTypes.string,
+}

--- a/src/shared/LogoutButton.js
+++ b/src/shared/LogoutButton.js
@@ -1,0 +1,26 @@
+import { deleteTokens } from 'shared/AuthTokens/deleteTokens'
+import React from 'react'
+import styled from 'styled-components'
+import { useHistory } from 'react-router-dom'
+
+const Button = styled.div`
+  padding-top: 12px;
+  padding-bottom: 12px;
+`
+
+export const LogoutButton = () => {
+  let history = useHistory()
+  const navigateToMenu = () => {
+    history.push('/menu')
+    history.go(0)
+  }
+  const confirmAndLogout = () => {
+    const logout = () => {
+      deleteTokens()
+      navigateToMenu()
+    }
+    var response = window.confirm('Tem certeza que quer deslogar?')
+    response && logout()
+  }
+  return <Button onClick={confirmAndLogout}> Sair </Button>
+}

--- a/src/shared/MenuDrawer.js
+++ b/src/shared/MenuDrawer.js
@@ -4,6 +4,7 @@ import { MenuButton } from 'shared/MenuButton'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import { colors } from 'shared/colors'
+import { LogoutButton } from 'shared/LogoutButton'
 
 const ListItemWrapper = styled.li`
   background-color: white;
@@ -19,7 +20,37 @@ const ListItemWrapper = styled.li`
 `
 const ListWrapper = styled.ul`
   margin: 0;
-  width: 25vh;
+  width: 20vw;
+  min-width: 150px;
+  max-width: 300px;
+`
+const LogoutButtonWrapper = styled.div`
+  @media (min-width: 600px) {
+    text-align: center;
+    position: fixed;
+    bottom: 0;
+    width: 20vw;
+    min-width: 150px;
+    max-width: 300px;
+    :hover {
+      background-color: ${colors.primary};
+      cursor: pointer;
+      color: white;
+    }
+  }
+  @media (max-width: 599px) {
+    text-align: center;
+    position: fixed;
+    bottom: 0;
+    width: 20vw;
+    min-width: 150px;
+    max-width: 300px;
+    :hover {
+      background-color: ${colors.primary};
+      cursor: pointer;
+      color: white;
+    }
+  }
 `
 
 export const MenuDrawer = () => {
@@ -46,6 +77,9 @@ export const MenuDrawer = () => {
           <ListItemWrapper onClick={navigateToMenus}>Menus</ListItemWrapper>
           <ListItemWrapper onClick={navigateToLessons}>Aulas</ListItemWrapper>
         </ListWrapper>
+        <LogoutButtonWrapper>
+          <LogoutButton />
+        </LogoutButtonWrapper>
       </Drawer>
       <MenuButton onClick={toggleDrawer} />
     </div>


### PR DESCRIPTION
Icon visual should now be fixed (as per https://github.com/ReisTecnologia/abc/issues/131):

![image](https://user-images.githubusercontent.com/70253649/112351313-8b09c600-8ca8-11eb-9391-1b3386bffeff.png)


Menu button should no longer be visible if the user type isnt admin
Logout button was implemented on the left drawer and on the menu page:

![image](https://user-images.githubusercontent.com/70253649/112350905-31090080-8ca8-11eb-871f-53d9fca4373a.png)

If the user is not signed in the logout button changes to a sign in button that navigates to the `/signin` page:

![image](https://user-images.githubusercontent.com/70253649/112351093-5990fa80-8ca8-11eb-8e19-0f1339800e5a.png)


