### PR TITLE
Menu element changes

### DIFF
--- a/src/EditLessonPage/EditableLesson/DeleteLessonImageButton.js
+++ b/src/EditLessonPage/EditableLesson/DeleteLessonImageButton.js
@@ -39,7 +39,7 @@ const DeleteLessonImageButtonBuilder = (size, deleteImageUrl) => (
   <Icon
     icon={trashIcon}
     onClick={deleteImageUrl}
-    color={colors.grayText}
+    color={colors.white}
     height={size}
     cursor="pointer"
   />

--- a/src/EditLessonPage/EditableLesson/DeleteLessonImageButton.js
+++ b/src/EditLessonPage/EditableLesson/DeleteLessonImageButton.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { colors } from 'shared/colors'
+import { Icon } from '@iconify/react'
+import trashIcon from '@iconify-icons/ion/trash'
+
+const Wrapper = styled.div`
+  @media (min-width: 376px) {
+    text-align: right;
+    display: flex;
+    align-items: center;
+    padding-left: 7px;
+    padding-right: 10px;
+    padding-bottom: 4px;
+    cursor: pointer;
+  }
+  @media (max-width: 375px) {
+    display: none;
+  }
+`
+
+const MobileWrapper = styled.div`
+  @media (min-width: 376px) {
+    display: none;
+  }
+  @media (max-width: 375px) {
+    text-align: right;
+    display: flex;
+    align-items: center;
+    padding-left: 7px;
+    padding-right: 10px;
+    padding-bottom: 3px;
+    cursor: pointer;
+  }
+`
+
+const DeleteLessonImageButtonBuilder = (size, deleteImageUrl) => (
+  <Icon
+    icon={trashIcon}
+    onClick={deleteImageUrl}
+    color={colors.grayText}
+    height={size}
+    cursor="pointer"
+  />
+)
+
+export const DeleteLessonImageButton = ({ setImageUrl }) => {
+  const deleteImageUrl = () => {
+    setImageUrl('')
+  }
+  return (
+    <>
+      <Wrapper>{DeleteLessonImageButtonBuilder('23', deleteImageUrl)}</Wrapper>
+      <MobileWrapper>
+        {DeleteLessonImageButtonBuilder('18', deleteImageUrl)}
+      </MobileWrapper>
+    </>
+  )
+}
+
+DeleteLessonImageButton.propTypes = {
+  setImageUrl: PropTypes.func,
+}

--- a/src/EditLessonPage/EditableLesson/EditableLesson.js
+++ b/src/EditLessonPage/EditableLesson/EditableLesson.js
@@ -44,7 +44,7 @@ let timeoutId = null
 export const EditableLesson = ({
   reloadLesson,
   loadingLesson,
-  lesson: { id, name, elements, image },
+  lesson: { id, name, elements, image, initials },
 }) => {
   const isFirstRun = useRef(true)
   const [mutate, { loading: isSaving }] = useMutation(SAVE_LESSON_MUTATION)
@@ -52,6 +52,7 @@ export const EditableLesson = ({
   const [innerElements, setInnerElements] = useState(elements)
   const [lessonName, setLessonName] = useState(name)
   const [imageUrl, setImageUrl] = useState(image)
+  const [lessonInitial, setLessonInitial] = useState(initials)
 
   useEffect(() => {
     if (!isFirstRun.current) {
@@ -105,13 +106,19 @@ export const EditableLesson = ({
         </CollapsedButtonsWrapper>
       </HeaderWrapper>
       <Container>
+        <LessonImage
+          id={id}
+          imageUrl={imageUrl}
+          setImageUrl={setImageUrl}
+          initials={lessonInitial}
+          setInitials={setLessonInitial}
+        />
         <EditableElements
           reloadLesson={reloadLesson}
           innerElements={innerElements}
           lessonId={id}
           setInnerElements={setInnerElements}
         />
-        <LessonImage id={id} imageUrl={imageUrl} setImageUrl={setImageUrl} />
       </Container>
     </Layout>
   )
@@ -123,6 +130,7 @@ EditableLesson.propTypes = {
     name: PropTypes.string,
     elements: PropTypes.arrayOf(PropTypes.any),
     image: PropTypes.string,
+    initials: PropTypes.string,
   }),
   loadingLesson: PropTypes.bool,
   reloadLesson: PropTypes.func,

--- a/src/EditLessonPage/EditableLesson/LessonImage.js
+++ b/src/EditLessonPage/EditableLesson/LessonImage.js
@@ -3,6 +3,7 @@ import { FileUploader } from './EditableElements/EditableElement/FileUploader'
 import { colors } from 'shared/colors'
 import { Spinner } from 'shared/Spinner'
 import styled from 'styled-components'
+import { DeleteLessonImageButton } from './DeleteLessonImageButton'
 import { DragAndDrop } from './EditableElements/EditableElement/DragAndDrop'
 import PropTypes from 'prop-types'
 
@@ -77,7 +78,7 @@ export const LessonImage = ({ id, imageUrl, setImageUrl }) => {
               <ImageWrapper>
                 <Img
                   src={`https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${imageUrl}`}
-                  alt="Imagem da aula"
+                  alt="Icone"
                 />
               </ImageWrapper>
               <FileUploader
@@ -87,6 +88,7 @@ export const LessonImage = ({ id, imageUrl, setImageUrl }) => {
                 loading={loading}
                 setLoading={setLoading}
               />
+              <DeleteLessonImageButton setImageUrl={setImageUrl} />
             </DragAndDrop>
           </ContentWrapper>
         </Wrapper>

--- a/src/EditLessonPage/EditableLesson/LessonImage.js
+++ b/src/EditLessonPage/EditableLesson/LessonImage.js
@@ -68,12 +68,12 @@ export const LessonImage = ({ id, imageUrl, setImageUrl }) => {
 
   return (
     <>
-      {loading ? (
-        <Spinner />
-      ) : (
-        <Wrapper>
-          <Title>Ícone para menus</Title>
-          <ContentWrapper>
+      <Wrapper>
+        <Title>Ícone para menus</Title>
+        <ContentWrapper>
+          {loading ? (
+            <Spinner />
+          ) : (
             <DragAndDrop imageFilePrefix={`${id}___`} setImageUrl={setImageUrl}>
               <ImageWrapper>
                 <Img
@@ -90,9 +90,9 @@ export const LessonImage = ({ id, imageUrl, setImageUrl }) => {
               />
               <DeleteLessonImageButton setImageUrl={setImageUrl} />
             </DragAndDrop>
-          </ContentWrapper>
-        </Wrapper>
-      )}
+          )}
+        </ContentWrapper>
+      </Wrapper>
     </>
   )
 }

--- a/src/EditLessonPage/EditableLesson/LessonImage.js
+++ b/src/EditLessonPage/EditableLesson/LessonImage.js
@@ -6,6 +6,8 @@ import styled from 'styled-components'
 import { DeleteLessonImageButton } from './DeleteLessonImageButton'
 import { DragAndDrop } from './EditableElements/EditableElement/DragAndDrop'
 import PropTypes from 'prop-types'
+import { LessonItem } from 'shared/LessonItem'
+import { TextAndInput } from 'shared/TextAndInput'
 
 const ImageWrapper = styled.div`
   background-color: ${colors.white};
@@ -20,11 +22,14 @@ const ImageWrapper = styled.div`
 `
 const Wrapper = styled.div`
   display: flex;
-  background-color: #eee;
+  background-color: ${colors.dimmedPrimary};
   flex-direction: column;
 `
 const Img = styled.img`
   border-radius: 5px;
+`
+const InitialWrapper = styled.div`
+  padding-right: 5px;
 `
 const Title = styled.div`
   @media (min-width: 361px) {
@@ -32,8 +37,8 @@ const Title = styled.div`
     text-align: center;
     margin: 1rem 0 0 0;
     font-size: 1.2rem;
-    color: ${colors.grayText};
-    border-bottom: solid 1px ${colors.grayText};
+    color: ${colors.white};
+    border-bottom: solid 1px ${colors.white};
     padding-bottom: 0.5rem;
   }
   @media (max-width: 360px) {
@@ -41,8 +46,8 @@ const Title = styled.div`
     text-align: center;
     margin: 1rem 0 0 0;
     font-size: 1.2rem;
-    color: ${colors.grayText};
-    border-bottom: solid 1px ${colors.grayText};
+    color: ${colors.white};
+    border-bottom: solid 1px ${colors.white};
     padding-bottom: 0.5rem;
     display: flex;
     flex-direction: column;
@@ -62,14 +67,26 @@ const ContentWrapper = styled.div`
     display: flex;
   }
 `
+const TextInputWrapper = styled.div`
+  display: flex;
+  align-self: center;
+  justify-content: space-between;
+  color: ${colors.white};
+`
 
-export const LessonImage = ({ id, imageUrl, setImageUrl }) => {
+export const LessonImage = ({
+  id,
+  imageUrl,
+  setImageUrl,
+  initials,
+  setInitials,
+}) => {
   const [loading, setLoading] = useState(false)
 
   return (
     <>
       <Wrapper>
-        <Title>Ícone para menus</Title>
+        <Title>Ícone</Title>
         <ContentWrapper>
           {loading ? (
             <Spinner />
@@ -83,12 +100,17 @@ export const LessonImage = ({ id, imageUrl, setImageUrl }) => {
               </ImageWrapper>
               <FileUploader
                 imageFilePrefix={`${id}___`}
-                color={colors.grayText}
+                color={colors.white}
                 setImageUrl={setImageUrl}
                 loading={loading}
                 setLoading={setLoading}
               />
               <DeleteLessonImageButton setImageUrl={setImageUrl} />
+              <LessonItem initials={initials} />
+              <TextInputWrapper>
+                <InitialWrapper>{'Inicial:'}</InitialWrapper>
+                <TextAndInput value={initials} onChange={setInitials} />
+              </TextInputWrapper>
             </DragAndDrop>
           )}
         </ContentWrapper>
@@ -101,4 +123,6 @@ LessonImage.propTypes = {
   id: PropTypes.string,
   imageUrl: PropTypes.string,
   setImageUrl: PropTypes.func,
+  initials: PropTypes.string,
+  setInitials: PropTypes.func,
 }

--- a/src/EditMenuPage/EditableMenu/EditableMenu.js
+++ b/src/EditMenuPage/EditableMenu/EditableMenu.js
@@ -120,7 +120,10 @@ export const EditableMenu = ({ menu: { id, name, elements }, lessons }) => {
       <Container>
         {innerElements.map(({ lessonId }, elementIndex) => (
           <ElementsWrapper key={elementIndex}>
-            <LessonItem lesson={filterLessonsById(lessonId, lessons)[0]} />
+            <LessonItem
+              initials={filterLessonsById(lessonId, lessons)[0].initials}
+              image={filterLessonsById(lessonId, lessons)[0].image}
+            />
             <ElementsInfoWrapper>
               <LessonNameWrapper>
                 <LessonName

--- a/src/EditMenuPage/EditableMenu/EditableMenu.js
+++ b/src/EditMenuPage/EditableMenu/EditableMenu.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useMutation } from '@apollo/client'
 import PropTypes from 'prop-types'
 import { Layout } from 'shared/Layout'
@@ -6,13 +6,11 @@ import { Spinner } from 'shared/Spinner'
 import { InputField } from 'shared/InputField'
 import { HeaderWrapper } from 'shared/HeaderWrapper'
 import { LessonItem } from 'shared/LessonItem'
-import { TextAndInput } from 'shared/TextAndInput'
 import { SAVE_MENU_MUTATION } from './SAVE_MENU_MUTATION'
 import { Container } from 'shared/Container'
 import { LessonSelect } from './LessonSelect'
+import { filterLessonsById } from 'shared/filterLessonsById'
 import { DeleteLessonButton } from './DeleteLessonButton'
-import { LESSONS_QUERY } from './LESSONS_QUERY'
-import { useQuery } from '@apollo/client'
 import {
   InicialWrapper,
   TitleWrapper,
@@ -33,25 +31,13 @@ import { ViewMenuButton } from './ViewMenuButton'
 
 const AUTO_SAVE_DEBOUNCE_MILISECONDS = 500
 let timeoutId = null
-const changeInitials = ({ innerElements, elementIndex, setInnerElements }) => (
-  initials
-) => {
-  const newInnerElements = [...innerElements]
-  newInnerElements[elementIndex] = {
-    ...newInnerElements[elementIndex],
-    initials,
-  }
-  setInnerElements(newInnerElements)
-}
+
 const changeLesson = ({ innerElements, elementIndex, setInnerElements }) => (
-  lessonId,
-  imageUrl
+  lessonId
 ) => {
   const newInnerElements = [...innerElements]
   newInnerElements[elementIndex] = {
     lessonId: lessonId,
-    initials: '?',
-    image: imageUrl,
   }
   setInnerElements(newInnerElements)
 }
@@ -66,17 +52,15 @@ const deleteLesson = ({
   setInnerElements(newinnerElements)
 }
 
-export const EditableMenu = ({ menu: { id, name, elements } }) => {
+export const EditableMenu = ({ menu: { id, name, elements }, lessons }) => {
   const isFirstRun = useRef(true)
-  const [innerElements, setInnerElements] = useState(elements)
-  const [isImageUpdated, setImageUpdated] = useState(false)
+  const mapElements = (elements) =>
+    elements.map(({ lessonId }) => ({ lessonId }))
+
+  const mappedElements = mapElements(elements)
+  const [innerElements, setInnerElements] = useState(mappedElements)
   const [menuName, setMenuName] = useState(name)
   const [mutate, { loading: isSaving }] = useMutation(SAVE_MENU_MUTATION)
-  const { data } = useQuery(LESSONS_QUERY, {
-    notifyOnNetworkStatusChange: true,
-    fetchPolicy: 'cache-and-network',
-  })
-
   const moveUp = ({ elementIndex }) => () => {
     const reorderedElements = [...innerElements]
     reorderedElements[elementIndex - 1] = innerElements[elementIndex]
@@ -91,35 +75,8 @@ export const EditableMenu = ({ menu: { id, name, elements } }) => {
     setInnerElements(reorderedElements)
   }
 
-  const lessons = useMemo(() => (data && data.lessons ? data.lessons : []), [
-    data,
-  ])
-  useEffect(() => {
-    if (lessons[0] !== undefined && !isImageUpdated) {
-      const filteredLessons = (lessonId) =>
-        lessons.filter((lesson) => lesson.id === lessonId)
-
-      const newInnerElements = [...innerElements]
-      innerElements.forEach((menu, elementIndex) => {
-        let lesson = filteredLessons(menu.lessonId)
-        if (lesson[0] !== undefined) {
-          newInnerElements[elementIndex] = {
-            lessonId: menu.lessonId,
-            initials: menu.initials,
-            image: lesson[0].image,
-          }
-        }
-      })
-      setImageUpdated(true)
-      setInnerElements(newInnerElements)
-    }
-  }, [innerElements, lessons, isImageUpdated])
-
-  const addLesson = (lessonId, imageUrl) =>
-    setInnerElements([
-      ...innerElements,
-      { lessonId: lessonId, initials: '?', image: imageUrl },
-    ])
+  const addLesson = (lessonId) =>
+    setInnerElements([...innerElements, { lessonId: lessonId }])
 
   useEffect(() => {
     if (!isFirstRun.current) {
@@ -161,13 +118,9 @@ export const EditableMenu = ({ menu: { id, name, elements } }) => {
         </ButtonsWrapper>
       </HeaderWrapper>
       <Container>
-        {innerElements.map(({ initials, lessonId, image }, elementIndex) => (
+        {innerElements.map(({ lessonId }, elementIndex) => (
           <ElementsWrapper key={elementIndex}>
-            {image && image !== 'null' ? (
-              <LessonItem imageUrl={image} />
-            ) : (
-              <LessonItem initials={initials} />
-            )}
+            <LessonItem lesson={filterLessonsById(lessonId, lessons)[0]} />
             <ElementsInfoWrapper>
               <LessonNameWrapper>
                 <LessonName
@@ -183,14 +136,7 @@ export const EditableMenu = ({ menu: { id, name, elements } }) => {
               </LessonNameWrapper>
               <InitialWrapper>
                 <InicialWrapper>Inicial:</InicialWrapper>
-                <TextAndInput
-                  value={initials}
-                  onChange={changeInitials({
-                    innerElements,
-                    elementIndex,
-                    setInnerElements,
-                  })}
-                />
+                {filterLessonsById(lessonId, lessons)[0].initials}
               </InitialWrapper>
             </ElementsInfoWrapper>
             <MoveButtons
@@ -225,4 +171,5 @@ EditableMenu.propTypes = {
   }),
   loadingMenu: PropTypes.bool,
   reloadMenu: PropTypes.func,
+  lessons: PropTypes.object,
 }

--- a/src/EditMenuPage/EditableMenu/LessonName.js
+++ b/src/EditMenuPage/EditableMenu/LessonName.js
@@ -3,6 +3,7 @@ import { LessonSelect } from './LessonSelect'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { useOnClickOutside } from 'shared/useOnClickOutside'
+import { filterLessonsById } from 'shared/filterLessonsById'
 
 export const Wrapper = styled.div`
   cursor: pointer;
@@ -12,9 +13,8 @@ export const Wrapper = styled.div`
 export const LessonName = ({ lessonId, onSelect, lessons, defaultSelect }) => {
   const [showSelect, setShowSelect] = useState(false)
   const toggleSelect = () => setShowSelect(true)
-  const filterLessonById = (id) => lessons.filter((lesson) => lesson.id === id)
-  const LessonName =
-    lessons.length > 0 ? filterLessonById(lessonId)[0].name : '...'
+
+  const LessonName = filterLessonsById(lessonId, lessons)[0].name
 
   const hideSelect = useCallback(() => {
     setShowSelect(false)

--- a/src/EditMenuPage/EditableMenu/LessonSelect.js
+++ b/src/EditMenuPage/EditableMenu/LessonSelect.js
@@ -3,17 +3,15 @@ import PropTypes from 'prop-types'
 
 export const LessonSelect = ({ onSelect, lessons, defaultSelect }) => {
   const handleChange = (e) => {
-    let splitTargetValue = e.target.value.split(',')
-
-    onSelect(splitTargetValue[0], splitTargetValue[1])
+    onSelect(e.target.value)
   }
 
   return (
     <>
       <select onChange={handleChange} value={defaultSelect}>
         <option value={null}>{null}</option>
-        {lessons.map(({ id, name, image }) => (
-          <option value={`${id},${image}`} key={id}>
+        {lessons.map(({ id, name }) => (
+          <option value={id} key={id}>
             {name}
           </option>
         ))}

--- a/src/EditMenuPage/EditableMenu/SAVE_MENU_MUTATION.js
+++ b/src/EditMenuPage/EditableMenu/SAVE_MENU_MUTATION.js
@@ -8,9 +8,7 @@ export const SAVE_MENU_MUTATION = gql`
         name
         id
         elements {
-          initials
           lessonId
-          image
         }
       }
     }

--- a/src/EditMenuPage/EditableMenuLoader.js
+++ b/src/EditMenuPage/EditableMenuLoader.js
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect } from 'react'
 import { useLazyQuery } from '@apollo/client'
 import { MENU_QUERY } from './MENU_QUERY'
+import { LESSONS_QUERY } from './LESSONS_QUERY'
 import { EditableMenu } from './EditableMenu/EditableMenu'
 import { useHistory, useParams } from 'react-router-dom'
 import { Spinner } from 'shared/Spinner'
@@ -15,13 +16,21 @@ export const EditableMenuLoader = () => {
       notifyOnNetworkStatusChange: true,
     }
   )
+  const [
+    loadLessonsData,
+    { data: lessonsData, loading: loadingLessons },
+  ] = useLazyQuery(LESSONS_QUERY, {
+    notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'cache-and-network',
+  })
   const { userData, userDataLoading } = useContext(CurrentUserContext)
 
   useEffect(() => {
     if (!userDataLoading && userData) {
       loadMenuData()
+      loadLessonsData()
     }
-  }, [loadMenuData, userData, userDataLoading])
+  }, [loadMenuData, loadLessonsData, userData, userDataLoading])
 
   let history = useHistory()
 
@@ -43,9 +52,12 @@ export const EditableMenuLoader = () => {
     alert('Você não tem permissões para acessar essa página!')
   }
 
-  return loadingMenu ? (
+  const menuLoaded = data && data.menu
+  const lessonsLoaded = lessonsData && lessonsData.lessons
+
+  return loadingMenu || loadingLessons ? (
     <Spinner />
-  ) : data && data.menu ? (
-    <EditableMenu menu={data.menu} />
+  ) : menuLoaded && lessonsLoaded ? (
+    <EditableMenu menu={data.menu} lessons={lessonsData.lessons} />
   ) : null
 }

--- a/src/EditMenuPage/LESSONS_QUERY.js
+++ b/src/EditMenuPage/LESSONS_QUERY.js
@@ -6,6 +6,7 @@ export const LESSONS_QUERY = gql`
       id
       name
       image
+      initials
     }
   }
 `

--- a/src/EditMenuPage/MENU_QUERY.js
+++ b/src/EditMenuPage/MENU_QUERY.js
@@ -6,9 +6,7 @@ export const MENU_QUERY = gql`
       id
       name
       elements {
-        initials
         lessonId
-        image
       }
     }
   }

--- a/src/LessonsPage/LESSONS_QUERY.js
+++ b/src/LessonsPage/LESSONS_QUERY.js
@@ -5,6 +5,8 @@ export const LESSONS_QUERY = gql`
     lessons {
       id
       name
+      image
+      initials
     }
   }
 `

--- a/src/MenuPage/MENU_QUERY.js
+++ b/src/MenuPage/MENU_QUERY.js
@@ -6,9 +6,12 @@ export const MENU_QUERY = gql`
       id
       name
       elements {
-        initials
         lessonId
-        image
+        lesson {
+          image
+          id
+          initials
+        }
       }
     }
   }

--- a/src/MenuPage/MenuPage.js
+++ b/src/MenuPage/MenuPage.js
@@ -3,6 +3,7 @@ import { useQuery } from '@apollo/client'
 import { MENU_QUERY } from './MENU_QUERY'
 import PropTypes from 'prop-types'
 import { mapMenu } from './mapMenu'
+import { filterLessonsById } from 'shared/filterLessonsById'
 import { LessonItem } from 'shared/LessonItem'
 import { Layout } from 'shared/Layout'
 import { HeaderWrapper } from 'shared/HeaderWrapper'
@@ -34,7 +35,11 @@ export const MenuPage = ({ id }) => {
         <Spinner />
       </Layout>
     )
+
   const menu = mapMenu(data.menu)
+
+  const lessons =
+    data && data.menu ? data.menu.elements.map(({ lesson }) => lesson) : []
 
   const showMenuButton =
     userData && userData.signedInUser.type === 'admin' ? true : false
@@ -46,16 +51,16 @@ export const MenuPage = ({ id }) => {
       <HeaderWrapper>{showMenuButton && <MenuDrawer />}</HeaderWrapper>
       <Container>
         <Wrapper>
-          {menu.elements.map(({ initials, lessonId, image }) => (
+          {menu.elements.map(({ lessonId }) => (
             <Link
               key={lessonId}
-              to={`/viewLesson/${lessonId}?initials=${initials}&menuId=${id}&image=${image}`}
+              to={`/viewLesson/${lessonId}?initials=${
+                filterLessonsById(lessonId, lessons)[0].initials
+              }&menuId=${id}&image=${
+                filterLessonsById(lessonId, lessons)[0].image
+              }`}
             >
-              {image && image !== 'null' ? (
-                <LessonItem imageUrl={image} />
-              ) : (
-                <LessonItem initials={initials} />
-              )}
+              <LessonItem lesson={filterLessonsById(lessonId, lessons)[0]} />
             </Link>
           ))}
         </Wrapper>

--- a/src/MenuPage/MenuPage.js
+++ b/src/MenuPage/MenuPage.js
@@ -52,15 +52,11 @@ export const MenuPage = ({ id }) => {
       <Container>
         <Wrapper>
           {menu.elements.map(({ lessonId }) => (
-            <Link
-              key={lessonId}
-              to={`/viewLesson/${lessonId}?initials=${
-                filterLessonsById(lessonId, lessons)[0].initials
-              }&menuId=${id}&image=${
-                filterLessonsById(lessonId, lessons)[0].image
-              }`}
-            >
-              <LessonItem lesson={filterLessonsById(lessonId, lessons)[0]} />
+            <Link key={lessonId} to={`/viewLesson/${lessonId}?menuId=${id}`}>
+              <LessonItem
+                initials={filterLessonsById(lessonId, lessons)[0].initials}
+                image={filterLessonsById(lessonId, lessons)[0].image}
+              />
             </Link>
           ))}
         </Wrapper>

--- a/src/MenuPage/mapMenu.js
+++ b/src/MenuPage/mapMenu.js
@@ -1,7 +1,5 @@
 export const mapMenu = (menu) => ({
-  elements: menu.elements.map(({ initials, lessonId, image }) => ({
-    initials,
+  elements: menu.elements.map(({ lessonId }) => ({
     lessonId,
-    image,
   })),
 })

--- a/src/ViewLessonPage/Lesson.js
+++ b/src/ViewLessonPage/Lesson.js
@@ -12,24 +12,24 @@ import { Link } from 'react-router-dom'
 import { MenuDrawer } from 'shared/MenuDrawer'
 import PropTypes from 'prop-types'
 
-export const Lesson = ({ initials, menuId, image }) => {
+export const Lesson = ({ menuId }) => {
   const { userData } = useContext(CurrentUserContext)
   const showMenuButton =
     userData && userData.signedInUser.type === 'admin' ? true : false
 
   const { lesson } = useParams()
   const { data } = useQuery(LESSON_QUERY, { variables: { id: lesson } })
+  console.log('data', data)
 
   return data ? (
     <Layout>
       <HeaderWrapper>
         {showMenuButton && <MenuDrawer />}
         <Link to={`/viewMenu/${menuId}`}>
-          {data.lesson.image ? (
-            <LessonItem imageUrl={image} />
-          ) : (
-            <LessonItem initials={initials} />
-          )}
+          <LessonItem
+            initials={data.lesson.initials}
+            image={data.lesson.image}
+          />
         </Link>
       </HeaderWrapper>
       <Container>

--- a/src/ViewLessonPage/LessonItem.js
+++ b/src/ViewLessonPage/LessonItem.js
@@ -37,7 +37,8 @@ const Img = styled.img`
   border-radius: 5px;
 `
 
-export const LessonItem = ({ initials, imageUrl, onClick }) => {
+export const LessonItem = ({ initials, image, onClick }) => {
+  const imageUrl = image && image !== '' ? image : null
   return (
     <>
       {imageUrl ? (
@@ -56,6 +57,6 @@ export const LessonItem = ({ initials, imageUrl, onClick }) => {
 
 LessonItem.propTypes = {
   initials: PropTypes.string,
-  imageUrl: PropTypes.string,
+  image: PropTypes.string,
   onClick: PropTypes.func,
 }

--- a/src/ViewLessonPage/LessonItem.js
+++ b/src/ViewLessonPage/LessonItem.js
@@ -44,7 +44,7 @@ export const LessonItem = ({ initials, imageUrl, onClick }) => {
         <ImageWrapper onClick={onClick}>
           <Img
             src={`https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${imageUrl}`}
-            alt="Imagem da aula"
+            alt="Icone"
           />
         </ImageWrapper>
       ) : (

--- a/src/ViewLessonPage/ViewLessonPage.js
+++ b/src/ViewLessonPage/ViewLessonPage.js
@@ -6,14 +6,12 @@ import { useLocation, useRouteMatch, Switch, Route } from 'react-router-dom'
 export const ViewLessonPage = () => {
   let { path } = useRouteMatch()
   const search = useLocation().search
-  const initials = new URLSearchParams(search).get('initials')
   const menuId = new URLSearchParams(search).get('menuId')
-  const image = new URLSearchParams(search).get('image')
 
   return (
     <Switch>
       <Route path={`${path}/:lesson`}>
-        <Lesson menuId={menuId} initials={initials} image={image} />
+        <Lesson menuId={menuId} />
       </Route>
     </Switch>
   )

--- a/src/lambda/dbData/db.js
+++ b/src/lambda/dbData/db.js
@@ -123,6 +123,7 @@ const addLesson = (id) => {
       name: 'Nova Aula',
       elements: [],
       image: '',
+      initials: '?',
     },
     TableName: TABLE_NAME,
   }

--- a/src/lambda/graphql.js
+++ b/src/lambda/graphql.js
@@ -227,6 +227,20 @@ const resolvers = {
       return { success, users }
     },
   },
+  MenuElement: {
+    lesson: async (parent) => {
+      const lesson = await db.getLesson(parent.lessonId)
+      return lesson
+        ? lesson
+        : {
+            id: 'deleted',
+            name: 'deleted',
+            elements: [],
+            initials: '',
+            image: '',
+          }
+    },
+  },
 }
 
 const server = new ApolloServer({

--- a/src/lambda/graphql/typeDefs.js
+++ b/src/lambda/graphql/typeDefs.js
@@ -49,13 +49,13 @@ export default gql`
     id: ID!
     name: String!
     elements: [Element]
+    initials: String!
     image: String
   }
 
   type MenuElement {
     lessonId: String!
-    initials: String!
-    image: String
+    lesson: Lesson!
   }
 
   type Menu {

--- a/src/shared/LESSON_QUERY.js
+++ b/src/shared/LESSON_QUERY.js
@@ -6,6 +6,7 @@ export const LESSON_QUERY = gql`
       id
       name
       image
+      initials
       elements {
         type
         letter

--- a/src/shared/LessonItem.js
+++ b/src/shared/LessonItem.js
@@ -35,8 +35,8 @@ const Img = styled.img`
   border-radius: 5px;
 `
 
-export const LessonItem = ({ lesson, onClick }) => {
-  const imageUrl = lesson.image && lesson.image !== '' ? lesson.image : null
+export const LessonItem = ({ initials, image, onClick }) => {
+  const imageUrl = image && image !== '' ? image : null
   return (
     <>
       {imageUrl ? (
@@ -47,13 +47,14 @@ export const LessonItem = ({ lesson, onClick }) => {
           />
         </ImageWrapper>
       ) : (
-        <Wrapper onClick={onClick}>{lesson.initials}</Wrapper>
+        <Wrapper onClick={onClick}>{initials}</Wrapper>
       )}
     </>
   )
 }
 
 LessonItem.propTypes = {
-  lesson: PropTypes.object,
+  initials: PropTypes.string,
+  image: PropTypes.string,
   onClick: PropTypes.func,
 }

--- a/src/shared/LessonItem.js
+++ b/src/shared/LessonItem.js
@@ -35,25 +35,25 @@ const Img = styled.img`
   border-radius: 5px;
 `
 
-export const LessonItem = ({ initials, imageUrl, onClick }) => {
+export const LessonItem = ({ lesson, onClick }) => {
+  const imageUrl = lesson.image && lesson.image !== '' ? lesson.image : null
   return (
     <>
       {imageUrl ? (
         <ImageWrapper onClick={onClick}>
           <Img
             src={`https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${imageUrl}`}
-            alt="Imagem da aula"
+            alt="Icone"
           />
         </ImageWrapper>
       ) : (
-        <Wrapper onClick={onClick}>{initials}</Wrapper>
+        <Wrapper onClick={onClick}>{lesson.initials}</Wrapper>
       )}
     </>
   )
 }
 
 LessonItem.propTypes = {
-  initials: PropTypes.string,
-  imageUrl: PropTypes.string,
+  lesson: PropTypes.object,
   onClick: PropTypes.func,
 }

--- a/src/shared/filterLessonsById.js
+++ b/src/shared/filterLessonsById.js
@@ -1,0 +1,13 @@
+export const filterLessonsById = (lessonId, lessons) => {
+  if (lessons.filter((lesson) => lesson.id === lessonId).length < 1)
+    return [
+      {
+        id: 'deleted',
+        name: 'deleted',
+        elements: [],
+        initials: '',
+        image: '',
+      },
+    ]
+  else return lessons.filter((lesson) => lesson.id === lessonId)
+}


### PR DESCRIPTION
The graphql type Lesson should now have image and initials while the type MenuElement should now only have lessonId.

If a menu has lessons that were deleted, those lessons should now appear with name as deleted and a blank icon: 

![image](https://user-images.githubusercontent.com/70253649/113044261-d2de9080-9173-11eb-91d5-e68193716e41.png)

When a new image is uploaded on a lesson, it should now be correctly updated on the menu page and edit menu page.

EditableLesson updated with initials and icon: 

![image](https://user-images.githubusercontent.com/70253649/113184431-89ea1300-922b-11eb-8e6a-8bb3b271b0aa.png)

ViewLesson should now display the image (if the lesson has one) or initial (if it doesnt have an image) regardless of which menu linked to the lesson
