### PR TITLE
User button

### DIFF
--- a/src/EditLessonPage/EditableLesson/CleanupFilesButton.js
+++ b/src/EditLessonPage/EditableLesson/CleanupFilesButton.js
@@ -13,12 +13,12 @@ const CLEANUP_LESSON_FILES_MUTATION = gql`
   }
 `
 const Wrapper = styled.div`
-  @media (min-width: 600px) {
+  @media (min-width: 720px) {
     padding-left: 5px;
     position: fixed;
-    right: 65px;
+    right: 105px;
   }
-  @media (max-width: 599px) {
+  @media (max-width: 719px) {
     min-width: 142px;
   }
 `

--- a/src/EditLessonPage/EditableLesson/CollapsedButtonsDrawer.js
+++ b/src/EditLessonPage/EditableLesson/CollapsedButtonsDrawer.js
@@ -7,6 +7,7 @@ import { DeleteButton } from './DeleteButton'
 import { CleanupFilesButton } from './CleanupFilesButton'
 import { ReloadButton } from './ReloadButton'
 import { ViewLessonButton } from './ViewLessonButton'
+import { LogoutButton } from 'shared/LogoutButton'
 import PropTypes from 'prop-types'
 
 const ListItemWrapper = styled.li`
@@ -23,7 +24,37 @@ const ListItemWrapper = styled.li`
 `
 const ListWrapper = styled.ul`
   margin: 0;
-  width: 25vh;
+  width: 20vw;
+  min-width: 150px;
+  max-width: 300px;
+`
+const LogoutButtonWrapper = styled.div`
+  @media (min-width: 600px) {
+    text-align: center;
+    position: fixed;
+    bottom: 0;
+    width: 20vw;
+    min-width: 150px;
+    max-width: 300px;
+    :hover {
+      background-color: ${colors.primary};
+      cursor: pointer;
+      color: white;
+    }
+  }
+  @media (max-width: 599px) {
+    text-align: center;
+    position: fixed;
+    bottom: 0;
+    width: 20vw;
+    min-width: 150px;
+    max-width: 300px;
+    :hover {
+      background-color: ${colors.primary};
+      cursor: pointer;
+      color: white;
+    }
+  }
 `
 
 export const CollapsedButtonsDrawer = ({
@@ -55,6 +86,9 @@ export const CollapsedButtonsDrawer = ({
             <ReloadButton reload={reload} loading={loading} />
           </ListItemWrapper>
         </ListWrapper>
+        <LogoutButtonWrapper>
+          <LogoutButton />
+        </LogoutButtonWrapper>
       </Drawer>
       <CollapsedButtons onClick={toggleDrawer} />
     </div>

--- a/src/EditLessonPage/EditableLesson/DeleteButton.js
+++ b/src/EditLessonPage/EditableLesson/DeleteButton.js
@@ -14,12 +14,12 @@ const DELETE_LESSON = gql`
   }
 `
 const Wrapper = styled.div`
-  @media (min-width: 600px) {
+  @media (min-width: 720px) {
     padding-left: 5px;
     position: fixed;
-    right: 207px;
+    right: 247px;
   }
-  @media (max-width: 599px) {
+  @media (max-width: 719px) {
   }
 `
 

--- a/src/EditLessonPage/EditableLesson/EditableLesson.js
+++ b/src/EditLessonPage/EditableLesson/EditableLesson.js
@@ -15,6 +15,7 @@ import { MenuDrawer } from 'shared/MenuDrawer'
 import { ViewLessonButton } from './ViewLessonButton'
 import { CollapsedButtonsDrawer } from './CollapsedButtonsDrawer'
 import { LessonImage } from './LessonImage'
+import { UserDrawer } from 'shared/UserDrawer/UserDrawer'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
@@ -22,22 +23,33 @@ export const TitleWrapper = styled.div`
   flex: 1;
 `
 export const CollapsedButtonsWrapper = styled.div`
-  @media (min-width: 600px) {
+  @media (min-width: 720px) {
     display: none;
   }
-  @media (max-width: 599px) {
+  @media (max-width: 719px) {
+    padding-left: 5px;
+    position: fixed;
+    right: 40px;
+    top: 3.5px;
   }
 `
 export const ButtonsWrapper = styled.div`
-  @media (min-width: 600px) {
+  @media (min-width: 720px) {
     flex: 1;
     display: flex;
     flex-direction: row-reverse;
   }
-  @media (max-width: 599px) {
+  @media (max-width: 719px) {
     display: none;
   }
 `
+
+export const UserButtonWrapper = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 1rem;
+`
+
 const AUTO_SAVE_DEBOUNCE_MILISECONDS = 500
 let timeoutId = null
 
@@ -45,6 +57,7 @@ export const EditableLesson = ({
   reloadLesson,
   loadingLesson,
   lesson: { id, name, elements, image },
+  userInitial,
 }) => {
   const isFirstRun = useRef(true)
   const [mutate, { loading: isSaving }] = useMutation(SAVE_LESSON_MUTATION)
@@ -77,8 +90,8 @@ export const EditableLesson = ({
   }, [mutate, id, lessonName, innerElements, imageUrl])
 
   let history = useHistory()
-  const navigateToHome = () => {
-    history.push('/')
+  const navigateToLessons = () => {
+    history.push('/lessons')
   }
 
   return (
@@ -89,16 +102,19 @@ export const EditableLesson = ({
           <InputField value={lessonName} setValue={setLessonName} />
         </TitleWrapper>
         {isSaving && <Spinner />}
+        <UserButtonWrapper>
+          <UserDrawer initial={userInitial} />
+        </UserButtonWrapper>
         <ButtonsWrapper>
           <ViewLessonButton lessonId={id} />
           <CleanupFilesButton id={id} />
-          <DeleteButton id={id} afterDelete={navigateToHome} />
+          <DeleteButton id={id} afterDelete={navigateToLessons} />
           <ReloadButton reload={reloadLesson} loading={loadingLesson} />
         </ButtonsWrapper>
         <CollapsedButtonsWrapper>
           <CollapsedButtonsDrawer
             id={id}
-            afterDelete={navigateToHome}
+            afterDelete={navigateToLessons}
             reload={reloadLesson}
             loading={loadingLesson}
           />
@@ -126,4 +142,5 @@ EditableLesson.propTypes = {
   }),
   loadingLesson: PropTypes.bool,
   reloadLesson: PropTypes.func,
+  userInitial: PropTypes.string,
 }

--- a/src/EditLessonPage/EditableLesson/ReloadButton.js
+++ b/src/EditLessonPage/EditableLesson/ReloadButton.js
@@ -5,12 +5,12 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
 const Wrapper = styled.div`
-  @media (min-width: 600px) {
+  @media (min-width: 720px) {
     padding-left: 5px;
     position: fixed;
-    right: 280px;
+    right: 320px;
   }
-  @media (max-width: 599px) {
+  @media (max-width: 719px) {
   }
 `
 

--- a/src/EditLessonPage/EditableLesson/ViewLessonButton.js
+++ b/src/EditLessonPage/EditableLesson/ViewLessonButton.js
@@ -5,13 +5,13 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 const Wrapper = styled.div`
-  @media (min-width: 600px) {
+  @media (min-width: 720px) {
     padding-left: 5px;
     position: fixed;
-    right: 10px;
+    right: 55px;
     top: 5px;
   }
-  @media (max-width: 599px) {
+  @media (max-width: 719px) {
   }
 `
 

--- a/src/EditLessonPage/EditableLessonLoader.js
+++ b/src/EditLessonPage/EditableLessonLoader.js
@@ -44,6 +44,7 @@ export const EditableLessonLoader = () => {
     navigateToMenu()
     alert('Você não tem permissões para acessar essa página!')
   }
+  const userInitial = userData.signedInUser.name.substr(0, 1).toUpperCase()
 
   return loadingLesson ? (
     <Spinner />
@@ -51,6 +52,7 @@ export const EditableLessonLoader = () => {
     <EditableLesson
       reloadLesson={reloadLesson}
       lesson={mapLesson(data.lesson)}
+      userInitial={userInitial}
     />
   ) : null
 }

--- a/src/EditMenuPage/EditableMenu/DeleteMenuButton.js
+++ b/src/EditMenuPage/EditableMenu/DeleteMenuButton.js
@@ -13,7 +13,7 @@ export const Button = styled.div`
   cursor: pointer;
   margin-left: 0.5rem;
   position: fixed;
-  right: 65px;
+  right: 105px;
 `
 
 const DELETE_MENU = gql`

--- a/src/EditMenuPage/EditableMenu/EditableMenu.js
+++ b/src/EditMenuPage/EditableMenu/EditableMenu.js
@@ -23,12 +23,14 @@ import {
   LabelWrapper,
   AddSelectWrapper,
   ElementsInfoWrapper,
+  UserButtonWrapper,
 } from './EditableMenu.styles'
 import { DeleteMenuButton } from './DeleteMenuButton'
 import { useHistory } from 'react-router-dom'
 import { LessonName } from './LessonName'
 import { MoveButtons } from './MoveButtons/MoveButtons'
 import { MenuDrawer } from 'shared/MenuDrawer'
+import { UserDrawer } from 'shared/UserDrawer/UserDrawer'
 import { ViewMenuButton } from './ViewMenuButton'
 
 const AUTO_SAVE_DEBOUNCE_MILISECONDS = 500
@@ -66,7 +68,7 @@ const deleteLesson = ({
   setInnerElements(newinnerElements)
 }
 
-export const EditableMenu = ({ menu: { id, name, elements } }) => {
+export const EditableMenu = ({ menu: { id, name, elements }, userInitial }) => {
   const isFirstRun = useRef(true)
   const [innerElements, setInnerElements] = useState(elements)
   const [isImageUpdated, setImageUpdated] = useState(false)
@@ -155,6 +157,9 @@ export const EditableMenu = ({ menu: { id, name, elements } }) => {
           <InputField value={menuName} setValue={setMenuName} />
         </TitleWrapper>
         {isSaving && <Spinner />}
+        <UserButtonWrapper>
+          <UserDrawer initial={userInitial} />
+        </UserButtonWrapper>
         <ButtonsWrapper>
           <ViewMenuButton menuId={id} />
           <DeleteMenuButton id={id} afterDelete={navigateToMenus} />
@@ -225,4 +230,5 @@ EditableMenu.propTypes = {
   }),
   loadingMenu: PropTypes.bool,
   reloadMenu: PropTypes.func,
+  userInitial: PropTypes.string,
 }

--- a/src/EditMenuPage/EditableMenu/EditableMenu.styles.js
+++ b/src/EditMenuPage/EditableMenu/EditableMenu.styles.js
@@ -12,6 +12,11 @@ export const InicialWrapper = styled.div`
 export const TitleWrapper = styled.div`
   flex: 1;
 `
+export const UserButtonWrapper = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 1rem;
+`
 export const ElementsInfoWrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/EditMenuPage/EditableMenu/ViewMenuButton.js
+++ b/src/EditMenuPage/EditableMenu/ViewMenuButton.js
@@ -8,6 +8,7 @@ const Wrapper = styled.div`
   padding-left: 5px;
   position: fixed;
   top: 5px;
+  right: 55px;
 `
 
 export const ViewMenuButton = ({ menuId }) => {

--- a/src/EditMenuPage/EditableMenuLoader.js
+++ b/src/EditMenuPage/EditableMenuLoader.js
@@ -43,9 +43,11 @@ export const EditableMenuLoader = () => {
     alert('Você não tem permissões para acessar essa página!')
   }
 
+  const userInitial = userData.signedInUser.name.substr(0, 1).toUpperCase()
+
   return loadingMenu ? (
     <Spinner />
   ) : data && data.menu ? (
-    <EditableMenu menu={data.menu} />
+    <EditableMenu menu={data.menu} userInitial={userInitial} />
   ) : null
 }

--- a/src/EditUserPage/EditableUser/EditableUser.js
+++ b/src/EditUserPage/EditableUser/EditableUser.js
@@ -9,10 +9,15 @@ import { Layout } from 'shared/Layout'
 import { MenuDrawer } from 'shared/MenuDrawer'
 import { UserInfoForm } from './UserInfoForm'
 import PropTypes from 'prop-types'
-import { Wrapper, FormsWrapper } from './EditableUser.styles.js'
+import {
+  Wrapper,
+  FormsWrapper,
+  UserButtonWrapper,
+} from './EditableUser.styles.js'
+import { UserDrawer } from 'shared/UserDrawer/UserDrawer'
 import { PasswordChangeForm } from './PasswordChangeForm'
 
-export const EditableUser = ({ user }) => {
+export const EditableUser = ({ user, userInitial }) => {
   const [userInfo, setUserInfo] = useState({
     login: user.login,
     name: user.name,
@@ -46,6 +51,9 @@ export const EditableUser = ({ user }) => {
     <Layout>
       <HeaderWrapper>
         <MenuDrawer />
+        <UserButtonWrapper>
+          <UserDrawer initial={userInitial} />
+        </UserButtonWrapper>
       </HeaderWrapper>
       <Container>
         <Wrapper>
@@ -76,4 +84,5 @@ export const EditableUser = ({ user }) => {
 EditableUser.propTypes = {
   user: PropTypes.object,
   afterComplete: PropTypes.func,
+  userInitial: PropTypes.string,
 }

--- a/src/EditUserPage/EditableUser/EditableUser.styles.js
+++ b/src/EditUserPage/EditableUser/EditableUser.styles.js
@@ -1,15 +1,37 @@
 import styled from 'styled-components'
 
 export const Form = styled.form`
-  display: flex;
-  flex-direction: column;
-  width: 25%;
-  align-items: center;
+  @media (min-width: 650px) {
+    display: flex;
+    flex-direction: column;
+    width: 25%;
+    align-items: center;
+  }
+
+  @media (max-width: 649px) {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    align-items: center;
+  }
 `
 export const Wrapper = styled.div`
-  margin-top: 35px;
-  display: flex;
-  justify-content: center;
+  @media (min-width: 650px) {
+    margin-top: 35px;
+    display: flex;
+    justify-content: center;
+  }
+
+  @media (max-width: 649px) {
+    margin-top: 35px;
+    display: flex;
+    justify-content: center;
+  }
+`
+export const UserButtonWrapper = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 1rem;
 `
 export const Label = styled.label`
   margin-bottom: 15px;
@@ -19,7 +41,17 @@ export const SubmitButton = styled.button`
   margin-top: 15px;
 `
 export const FormsWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  width: 100%;
+  @media (min-width: 650px) {
+    display: flex;
+    justify-content: space-around;
+    width: 100%;
+  }
+
+  @media (max-width: 649px) {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
+  }
 `

--- a/src/EditUserPage/EditableUserLoader.js
+++ b/src/EditUserPage/EditableUserLoader.js
@@ -43,9 +43,11 @@ export const EditableUserLoader = () => {
     alert('Você não tem permissões para acessar essa página!')
   }
 
+  const userInitial = userData.signedInUser.name.substr(0, 1).toUpperCase()
+
   return loadingUser ? (
     <Spinner />
   ) : data && data.user ? (
-    <EditableUser user={data.user} />
+    <EditableUser user={data.user} userInitial={userInitial} />
   ) : null
 }

--- a/src/LessonsPage/LessonsPage.js
+++ b/src/LessonsPage/LessonsPage.js
@@ -5,12 +5,13 @@ import { AddLessonButton } from './AddLessonButton/AddLessonButton'
 import { ListItem } from './ListItem/ListItem'
 import { Spinner } from 'shared/Spinner'
 import { LESSONS_QUERY } from './LESSONS_QUERY'
-import { Title, PageActions } from './LessonsPage.styles.js'
+import { Title, PageActions, UserButtonWrapper } from './LessonsPage.styles.js'
 import { Layout } from 'shared/Layout'
 import { HeaderWrapper } from 'shared/HeaderWrapper'
 import { Container } from 'shared/Container'
 import { MenuDrawer } from 'shared/MenuDrawer'
 import { useHistory } from 'react-router'
+import { UserDrawer } from 'shared/UserDrawer/UserDrawer'
 import PropTypes from 'prop-types'
 
 export const LessonsPage = () => {
@@ -44,6 +45,8 @@ export const LessonsPage = () => {
     alert('Você não tem permissões para acessar essa página!')
     navigateToMenu()
   }
+  const userInitial = userData.signedInUser.name.substr(0, 1).toUpperCase()
+
   return (
     <Layout>
       <HeaderWrapper>
@@ -51,6 +54,9 @@ export const LessonsPage = () => {
         <Title>Aulas</Title>
         {loading && <Spinner />}
         <PageActions>
+          <UserButtonWrapper>
+            <UserDrawer initial={userInitial} />
+          </UserButtonWrapper>
           <AddLessonButton afterAdd={refetch} />
         </PageActions>
       </HeaderWrapper>

--- a/src/LessonsPage/LessonsPage.styles.js
+++ b/src/LessonsPage/LessonsPage.styles.js
@@ -12,6 +12,11 @@ export const Title = styled.div`
     font-size: 1.3rem;
   }
 `
+export const UserButtonWrapper = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 1rem;
+`
 
 export const PageActions = styled.div`
   @media (min-width: 361px) {
@@ -23,6 +28,7 @@ export const PageActions = styled.div`
   @media (max-width: 360px) {
     flex: 1;
     display: flex;
+    margin-right: 1.5rem;
     flex-direction: row-reverse;
   }
 `

--- a/src/MenuPage/MenuPage.js
+++ b/src/MenuPage/MenuPage.js
@@ -13,6 +13,7 @@ import { MenuDrawer } from 'shared/MenuDrawer'
 import { Container } from 'shared/Container'
 import { Spinner } from 'shared/Spinner'
 import { CurrentUserContext } from '../CurrentUserContextProvider'
+import { UserDrawer } from 'shared/UserDrawer/UserDrawer'
 import { SignInOrOutButton } from './SignInOrOutButton'
 
 const Wrapper = styled.div`
@@ -22,6 +23,11 @@ const Wrapper = styled.div`
   align-content: space-around;
   background-color: ${colors.primary};
   height: 100%;
+`
+export const UserButtonWrapper = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 1rem;
 `
 
 export const MenuPage = ({ id }) => {
@@ -40,10 +46,19 @@ export const MenuPage = ({ id }) => {
     userData && userData.signedInUser.type === 'admin' ? true : false
 
   const showLogoutButton = userData && userData.signedInUser.type
+  const userInitial =
+    userData && userData.signedInUser.name.substr(0, 1).toUpperCase()
 
   return (
     <Layout backgroundColor={colors.primary}>
-      <HeaderWrapper>{showMenuButton && <MenuDrawer />}</HeaderWrapper>
+      {userData && (
+        <HeaderWrapper>
+          {showMenuButton && <MenuDrawer />}
+          <UserButtonWrapper>
+            <UserDrawer initial={userInitial} />
+          </UserButtonWrapper>
+        </HeaderWrapper>
+      )}
       <Container>
         <Wrapper>
           {menu.elements.map(({ initials, lessonId, image }) => (

--- a/src/MenuPage/SignInOrOutButton.js
+++ b/src/MenuPage/SignInOrOutButton.js
@@ -10,7 +10,7 @@ const SignInOrOutButtonWrapper = styled.div`
   position: fixed;
   text-align: center;
   bottom: 20px;
-  left: calc(50% - 80px);
+  left: calc(50% - 40px);
   min-width: 80px;
   border: solid 1px ${colors.white};
   border-radius: 7px;

--- a/src/MenusPage/MenusPage.js
+++ b/src/MenusPage/MenusPage.js
@@ -6,11 +6,12 @@ import { AddMenuButton } from './AddMenuButton/AddMenuButton'
 import { ListItem } from './ListItem/ListItem'
 import { Spinner } from 'shared/Spinner'
 import { MENUS_QUERY } from './MENUS_QUERY'
-import { Title, PageActions } from './MenusPage.styles.js'
+import { Title, PageActions, UserButtonWrapper } from './MenusPage.styles.js'
 import { Layout } from 'shared/Layout'
 import { HeaderWrapper } from 'shared/HeaderWrapper'
 import { Container } from 'shared/Container'
 import { MenuDrawer } from 'shared/MenuDrawer'
+import { UserDrawer } from 'shared/UserDrawer/UserDrawer'
 
 export const MenusPage = () => {
   const { userData, userDataLoading } = useContext(CurrentUserContext)
@@ -41,6 +42,7 @@ export const MenusPage = () => {
     alert('Você não tem permissões para acessar essa página!')
     navigateToMenu()
   }
+  const userInitial = userData.signedInUser.name.substr(0, 1).toUpperCase()
 
   return (
     <Layout>
@@ -49,6 +51,9 @@ export const MenusPage = () => {
         <Title>Menus</Title>
         {loading && <Spinner />}
         <PageActions>
+          <UserButtonWrapper>
+            <UserDrawer initial={userInitial} />
+          </UserButtonWrapper>
           <AddMenuButton afterAdd={refetch} />
         </PageActions>
       </HeaderWrapper>

--- a/src/MenusPage/MenusPage.styles.js
+++ b/src/MenusPage/MenusPage.styles.js
@@ -12,6 +12,11 @@ export const Title = styled.div`
     font-size: 1.3rem;
   }
 `
+export const UserButtonWrapper = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 1rem;
+`
 
 export const PageActions = styled.div`
   @media (min-width: 361px) {
@@ -23,6 +28,7 @@ export const PageActions = styled.div`
   @media (max-width: 360px) {
     flex: 1;
     display: flex;
+    margin-right: 1.5rem;
     flex-direction: row-reverse;
   }
 `

--- a/src/UsersPage/AddUserButton/AddUserButton.js
+++ b/src/UsersPage/AddUserButton/AddUserButton.js
@@ -13,7 +13,7 @@ export const Button = styled.div`
   border: solid 1px ${colors.white};
   border-radius: 7px;
   padding: 0 0.4rem;
-  min-width: 135px;
+  min-width: 145px;
   max-height: 22px;
 `
 

--- a/src/UsersPage/UserPage.styles.js
+++ b/src/UsersPage/UserPage.styles.js
@@ -1,9 +1,14 @@
 import styled from 'styled-components'
 
 export const Title = styled.div`
-  @media (min-width: 361px) {
+  @media (min-width: 401px) {
     flex: 1;
     margin-left: 2rem;
+    font-size: 1.3rem;
+  }
+  @media (max-width: 400px) {
+    flex: 1;
+    margin-left: 1rem;
     font-size: 1.3rem;
   }
   @media (max-width: 360px) {
@@ -11,6 +16,12 @@ export const Title = styled.div`
     margin-left: 0.5rem;
     font-size: 1.3rem;
   }
+`
+
+export const UserButtonWrapper = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 1rem;
 `
 
 export const PageActions = styled.div`
@@ -23,6 +34,7 @@ export const PageActions = styled.div`
   @media (max-width: 360px) {
     flex: 1;
     display: flex;
+    margin-right: 1.5rem;
     flex-direction: row-reverse;
   }
 `

--- a/src/UsersPage/UsersPage.js
+++ b/src/UsersPage/UsersPage.js
@@ -6,11 +6,12 @@ import { AddUserButton } from './AddUserButton/AddUserButton'
 import { ListItem } from './ListItem/ListItem'
 import { Spinner } from 'shared/Spinner'
 import { USERS_QUERY } from './USERS_QUERY'
-import { Title, PageActions } from './UserPage.styles.js'
+import { Title, PageActions, UserButtonWrapper } from './UserPage.styles.js'
 import { Layout } from 'shared/Layout'
 import { HeaderWrapper } from 'shared/HeaderWrapper'
 import { Container } from 'shared/Container'
 import { MenuDrawer } from 'shared/MenuDrawer'
+import { UserDrawer } from 'shared/UserDrawer/UserDrawer'
 
 export const UsersPage = () => {
   const { userData, userDataLoading } = useContext(CurrentUserContext)
@@ -41,6 +42,7 @@ export const UsersPage = () => {
     alert('Você não tem permissões para acessar essa página!')
     navigateToMenu()
   }
+  const userInitial = userData.signedInUser.name.substr(0, 1).toUpperCase()
 
   return (
     <Layout>
@@ -49,6 +51,9 @@ export const UsersPage = () => {
         <Title>Usuários</Title>
         {loading && <Spinner />}
         <PageActions>
+          <UserButtonWrapper>
+            <UserDrawer initial={userInitial} />
+          </UserButtonWrapper>
           <AddUserButton afterAdd={refetch} />
         </PageActions>
       </HeaderWrapper>

--- a/src/ViewLessonPage/Lesson.js
+++ b/src/ViewLessonPage/Lesson.js
@@ -11,6 +11,14 @@ import { LessonItem } from './LessonItem'
 import { Link } from 'react-router-dom'
 import { MenuDrawer } from 'shared/MenuDrawer'
 import PropTypes from 'prop-types'
+import { UserDrawer } from 'shared/UserDrawer/UserDrawer'
+import styled from 'styled-components'
+
+export const UserButtonWrapper = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 1rem;
+`
 
 export const Lesson = ({ initials, menuId, image }) => {
   const { userData } = useContext(CurrentUserContext)
@@ -20,10 +28,16 @@ export const Lesson = ({ initials, menuId, image }) => {
   const { lesson } = useParams()
   const { data } = useQuery(LESSON_QUERY, { variables: { id: lesson } })
 
+  const userInitial =
+    userData && userData.signedInUser.name.substr(0, 1).toUpperCase()
+
   return data ? (
     <Layout>
       <HeaderWrapper>
         {showMenuButton && <MenuDrawer />}
+        <UserButtonWrapper>
+          <UserDrawer initial={userInitial} />
+        </UserButtonWrapper>
         <Link to={`/viewMenu/${menuId}`}>
           {data.lesson.image ? (
             <LessonItem imageUrl={image} />

--- a/src/ViewUserPage/UserPage.js
+++ b/src/ViewUserPage/UserPage.js
@@ -3,9 +3,15 @@ import { HeaderWrapper } from 'shared/HeaderWrapper'
 import { Container } from 'shared/Container'
 import { Layout } from 'shared/Layout'
 import { MenuDrawer } from 'shared/MenuDrawer'
+import { UserDrawer } from 'shared/UserDrawer/UserDrawer'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
+export const UserButtonWrapper = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 1rem;
+`
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -33,12 +39,15 @@ const userInfoFields = (label, userInfo) => (
   </InfoWrapper>
 )
 
-export const UserPage = ({ user }) => {
+export const UserPage = ({ user, userInitial }) => {
   return (
     <Layout>
       <HeaderWrapper>
         <MenuDrawer />
         <Title>Usuário</Title>
+        <UserButtonWrapper>
+          <UserDrawer initial={userInitial} />
+        </UserButtonWrapper>
       </HeaderWrapper>
       <Container>
         <Wrapper>
@@ -56,4 +65,5 @@ export const UserPage = ({ user }) => {
 
 UserPage.propTypes = {
   user: PropTypes.object,
+  userInitial: PropTypes.string,
 }

--- a/src/ViewUserPage/ViewUserLoader.js
+++ b/src/ViewUserPage/ViewUserLoader.js
@@ -45,9 +45,11 @@ export const ViewUserLoader = () => {
     alert('Você não tem permissões para acessar essa página!')
   }
 
+  const userInitial = userData.signedInUser.name.substr(0, 1).toUpperCase()
+
   return userLoading ? (
     <Spinner />
   ) : data && data.user ? (
-    <UserPage user={data.user} />
+    <UserPage user={data.user} userInitial={userInitial} />
   ) : null
 }

--- a/src/shared/MenuDrawer.js
+++ b/src/shared/MenuDrawer.js
@@ -4,7 +4,6 @@ import { MenuButton } from 'shared/MenuButton'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import { colors } from 'shared/colors'
-import { LogoutButton } from 'shared/LogoutButton'
 
 const ListItemWrapper = styled.li`
   background-color: white;
@@ -23,34 +22,6 @@ const ListWrapper = styled.ul`
   width: 20vw;
   min-width: 150px;
   max-width: 300px;
-`
-const LogoutButtonWrapper = styled.div`
-  @media (min-width: 600px) {
-    text-align: center;
-    position: fixed;
-    bottom: 0;
-    width: 20vw;
-    min-width: 150px;
-    max-width: 300px;
-    :hover {
-      background-color: ${colors.primary};
-      cursor: pointer;
-      color: white;
-    }
-  }
-  @media (max-width: 599px) {
-    text-align: center;
-    position: fixed;
-    bottom: 0;
-    width: 20vw;
-    min-width: 150px;
-    max-width: 300px;
-    :hover {
-      background-color: ${colors.primary};
-      cursor: pointer;
-      color: white;
-    }
-  }
 `
 
 export const MenuDrawer = () => {
@@ -82,9 +53,6 @@ export const MenuDrawer = () => {
           <ListItemWrapper onClick={navigateToLessons}>Aulas</ListItemWrapper>
           <ListItemWrapper onClick={navigateToUsers}>Usuários</ListItemWrapper>
         </ListWrapper>
-        <LogoutButtonWrapper>
-          <LogoutButton />
-        </LogoutButtonWrapper>
       </Drawer>
       <MenuButton onClick={toggleDrawer} />
     </div>

--- a/src/shared/UserDrawer/UserButton.js
+++ b/src/shared/UserDrawer/UserButton.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+
+const Wrapper = styled.div`
+  @media (min-width: 600px) {
+    border-radius: 50%;
+    border: solid white 1px;
+    min-width: 22px;
+    text-align: center;
+    :hover {
+      cursor: pointer;
+    }
+  }
+  @media (max-width: 599px) {
+    border-radius: 50%;
+    border: solid white 1px;
+    min-width: 22px;
+    text-align: center;
+    :hover {
+      cursor: pointer;
+    }
+  }
+`
+const Button = styled.div``
+
+export const UserButton = ({ onClick, initial }) => {
+  return (
+    <Wrapper onClick={onClick}>
+      <Button>{initial}</Button>
+    </Wrapper>
+  )
+}
+
+UserButton.propTypes = {
+  onClick: PropTypes.func,
+  initial: PropTypes.string,
+}

--- a/src/shared/UserDrawer/UserDrawer.js
+++ b/src/shared/UserDrawer/UserDrawer.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react'
+import { Drawer } from '@material-ui/core'
+import styled from 'styled-components'
+import { colors } from 'shared/colors'
+import PropTypes from 'prop-types'
+import { LogoutButton } from 'shared/LogoutButton'
+import { UserButton } from './UserButton'
+
+const ListItemWrapper = styled.li`
+  background-color: white;
+  :hover {
+    background-color: ${colors.primary};
+    cursor: pointer;
+    color: white;
+  }
+  list-style-type: none;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  text-align: center;
+`
+const ListWrapper = styled.ul`
+  margin: 0;
+  width: 20vw;
+  min-width: 150px;
+  max-width: 300px;
+`
+
+export const UserDrawer = ({ initial }) => {
+  const [drawer, setDrawer] = useState(false)
+
+  const toggleDrawer = () => {
+    setDrawer(!drawer)
+  }
+
+  return (
+    <div>
+      <Drawer open={drawer} onClose={toggleDrawer} anchor="right">
+        <ListWrapper>
+          <ListItemWrapper>
+            <LogoutButton />
+          </ListItemWrapper>
+        </ListWrapper>
+      </Drawer>
+      <UserButton onClick={toggleDrawer} initial={initial} />
+    </div>
+  )
+}
+
+UserDrawer.propTypes = {
+  initial: PropTypes.string,
+}


### PR DESCRIPTION
New user button on the right side of the header that displays the initial of the logged in user:

![image](https://user-images.githubusercontent.com/70253649/113206730-30dba880-9246-11eb-9322-4ee441682290.png)

When clicked should open a right drawer with the option of logging out: 

![image](https://user-images.githubusercontent.com/70253649/113206788-4224b500-9246-11eb-92da-0fe103180641.png)

The menu page should no longer display the empty header in case the user isnt logged in: 

![image](https://user-images.githubusercontent.com/70253649/113206914-697b8200-9246-11eb-83d0-3b7c69825951.png)

And, in case the user is logged in but is not an admin, should only display the user on the right side if the user is logged in:

![image](https://user-images.githubusercontent.com/70253649/113207049-8c0d9b00-9246-11eb-8172-038247663d9c.png)

When deleting a lesson you should now correctly be redirected to `/lessons` page




