### PR TITLE
admin only pencil button

### DIFF
--- a/src/ViewLessonPage/EditLessonButton.js
+++ b/src/ViewLessonPage/EditLessonButton.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+
+export const Wrapper = styled.div`
+  cursor: pointer;
+`
+
+export const EditLessonButton = ({ color, onClick }) => {
+  return (
+    <Wrapper onClick={onClick}>
+      <svg
+        version="1.1"
+        id="Layer_1"
+        xmlns="http://www.w3.org/2000/svg"
+        x="0px"
+        y="0px"
+        width="23px"
+        height="23px"
+        viewBox="0 0 512 512"
+        enableBackground="new 0 0 512 512"
+        xmlSpace="preserve"
+      >
+        <g color={color} fill="currentcolor">
+          <path
+            d="M422.953,176.019c0.549-0.48,1.09-0.975,1.612-1.498l21.772-21.772c12.883-12.883,12.883-33.771,0-46.654
+		l-40.434-40.434c-12.883-12.883-33.771-12.883-46.653,0l-21.772,21.772c-0.523,0.523-1.018,1.064-1.498,1.613L422.953,176.019z"
+          />
+          <polygon points="114.317,397.684 157.317,440.684 106.658,448.342 56,456 63.658,405.341 71.316,354.683 	" />
+          <polygon
+            points="349.143,125.535 118.982,355.694 106.541,343.253 336.701,113.094 324.26,100.653 81.659,343.253 
+		168.747,430.341 411.348,187.74 	"
+          />
+        </g>
+      </svg>
+    </Wrapper>
+  )
+}
+
+EditLessonButton.propTypes = {
+  onClick: PropTypes.func,
+  color: PropTypes.string,
+}

--- a/src/ViewLessonPage/Lesson.js
+++ b/src/ViewLessonPage/Lesson.js
@@ -4,10 +4,16 @@ import { Container } from 'shared/Container'
 import { Header } from 'shared/Header/Header'
 import { ViewableElements } from './ViewableElements/ViewableElements'
 import { LessonItem } from './LessonItem'
-import { Link } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
+import { EditLessonButton } from './EditLessonButton'
 import PropTypes from 'prop-types'
+import { colors } from 'shared/colors'
 
 export const Lesson = ({ menuId, lesson }) => {
+  let history = useHistory()
+  const navigateToEditLesson = () => {
+    history.push(`/editLesson/${lesson.id}`)
+  }
   return (
     <Layout>
       <Header
@@ -15,6 +21,12 @@ export const Lesson = ({ menuId, lesson }) => {
           <Link to={`/viewMenu/${menuId}`}>
             <LessonItem initials={lesson.initials} image={lesson.image} />
           </Link>
+        }
+        adminPageActions={
+          <EditLessonButton
+            color={colors.white}
+            onClick={navigateToEditLesson}
+          />
         }
       />
       <Container>

--- a/src/shared/Header/Header.js
+++ b/src/shared/Header/Header.js
@@ -7,17 +7,26 @@ import { CurrentUserContext } from 'shared/CurrentUserContextProvider'
 import { Spinner } from 'shared/Spinner'
 import { UserButtonWrapper, PageActions, Title } from './Header.styles.js'
 
-export const Header = ({ title, loading, pageActions, lessonIcon }) => {
+export const Header = ({
+  title,
+  loading,
+  pageActions,
+  lessonIcon,
+  adminPageActions,
+}) => {
   const { user } = useContext(CurrentUserContext)
-  const showMenuButton =
+  const showAdminOnlyButtons =
     user && user.signedInUser.type === 'admin' ? true : false
   return user ? (
     <HeaderWrapper>
-      {showMenuButton && <MenuDrawer />}
+      {showAdminOnlyButtons && <MenuDrawer />}
       {title && <Title>{title}</Title>}
       {lessonIcon}
       {loading && <Spinner />}
       {pageActions && <PageActions>{pageActions}</PageActions>}
+      {adminPageActions && showAdminOnlyButtons ? (
+        <PageActions>{adminPageActions}</PageActions>
+      ) : null}
       <UserButtonWrapper>
         <UserDrawer initial={user.initial} />
       </UserButtonWrapper>
@@ -30,4 +39,5 @@ Header.propTypes = {
   loading: PropTypes.bool,
   pageActions: PropTypes.element,
   lessonIcon: PropTypes.element,
+  adminPageActions: PropTypes.element,
 }


### PR DESCRIPTION
ViewLessonPage should now display on its header a pencil button that redirects to the editLessonPage, but should only be visible to admins.
![image](https://user-images.githubusercontent.com/70253649/113604272-67853a80-961b-11eb-8a1e-c9194d7ceb7c.png)
