### PR TITLE
parcial query error handling

### DIFF
--- a/src/EditMenuPage/EditableMenuLoader.js
+++ b/src/EditMenuPage/EditableMenuLoader.js
@@ -8,20 +8,30 @@ import { Spinner } from 'shared/Spinner'
 
 export const EditableMenuLoader = () => {
   let { menu } = useParams()
-  const { data, loading: loadingMenu, error } = useQuery(MENU_QUERY, {
-    variables: { id: menu },
-    notifyOnNetworkStatusChange: true,
-  })
-  const { data: lessonsData, loading: loadingLessons } = useQuery(
-    LESSONS_QUERY,
+  const { data, loading: loadingMenu, error: menuQueryError } = useQuery(
+    MENU_QUERY,
     {
+      variables: { id: menu },
       notifyOnNetworkStatusChange: true,
-      fetchPolicy: 'cache-and-network',
     }
   )
+  const {
+    data: lessonsData,
+    loading: loadingLessons,
+    error: lessonsQueryError,
+  } = useQuery(LESSONS_QUERY, {
+    notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'cache-and-network',
+  })
+  const error = menuQueryError
+    ? menuQueryError
+    : lessonsQueryError
+    ? lessonsQueryError
+    : null
 
   if (error) {
     console.error(error)
+    return <span>Erro ao carregar {menuQueryError ? 'menu' : 'aulas'}</span>
   }
   const menuLoaded = data && data.menu
   const lessonsLoaded = lessonsData && lessonsData.lessons

--- a/src/lambda/graphql.js
+++ b/src/lambda/graphql.js
@@ -248,6 +248,10 @@ const server = new ApolloServer({
   resolvers,
   introspection: true,
   playground: true,
+  formatError: (err) => {
+    console.error(err)
+    return err
+  },
   context: ({ context }) => context,
 })
 


### PR DESCRIPTION
If an error occurs on the query, the EditMenuPage should now render a message stating that there was an error loading the menus or lessons whichever query happened to throw an error, and the error should now correctly display on the console:
![image](https://user-images.githubusercontent.com/70253649/113754934-21e17400-96e6-11eb-9fd0-de588ad29820.png)
