### PR TITLE
editUser error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22916,6 +22916,14 @@
         "use-latest": "^1.0.0"
       }
     },
+    "react-toastify": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-7.0.3.tgz",
+      "integrity": "sha512-cxZ5rfurC8LzcZQMTYc8RHIkQTs+BFur18Pzk6Loz6uS8OXUWm6nXVlH/wqglz4Z7UAE8xxcF5mRjfE13487uQ==",
+      "requires": {
+        "clsx": "^1.1.1"
+      }
+    },
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.0.1",
+    "react-toastify": "^7.0.3",
     "serverless-http": "^2.7.0",
     "styled-components": "^4.4.0",
     "utf-8-validate": "^5.0.3",

--- a/src/EditUserPage/EditableUser/EditableUser.js
+++ b/src/EditUserPage/EditableUser/EditableUser.js
@@ -10,6 +10,8 @@ import PropTypes from 'prop-types'
 import { Wrapper, FormsWrapper } from './EditableUser.styles.js'
 import { PasswordChangeForm } from './PasswordChangeForm'
 import { Header } from 'shared/Header/Header'
+import { ToastContainer, toast, Slide } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
 
 export const EditableUser = ({ user }) => {
   const [userInfo, setUserInfo] = useState({
@@ -23,12 +25,20 @@ export const EditableUser = ({ user }) => {
   const afterComplete = () => {
     setUserInfo({ ...userInfo, previousLogin: user.login })
   }
+  const onSaveUserError = () => {
+    toast.error('Erro ao salvar usuário', {
+      position: 'top-center',
+      hideProgressBar: true,
+      transition: Slide,
+    })
+  }
   const [saveUser, { loading }] = useMutation(SAVE_USER_MUTATION, {
     variables: {
       id: user.id,
       input: userInfo,
     },
     onCompleted: afterComplete,
+    onError: onSaveUserError,
   })
 
   const [savePassword, { loading: savePasswordLoading }] = useMutation(
@@ -62,6 +72,7 @@ export const EditableUser = ({ user }) => {
                 setConfirmPassword={setConfirmPassword}
                 savePassword={savePassword}
               />
+              <ToastContainer />
             </FormsWrapper>
           )}
         </Wrapper>

--- a/src/EditUserPage/EditableUser/UserInfoForm.js
+++ b/src/EditUserPage/EditableUser/UserInfoForm.js
@@ -28,8 +28,8 @@ export const UserInfoForm = ({ setUserInfo, userInfo, saveUser }) => {
       <input type="text" value={userInfo.name} onChange={handleNameChange} />
       <Label>Tipo de usuário:</Label>
       <select onChange={handleTypeChange} value={userInfo.type}>
-        <option value={'admin'}>{'Admin'}</option>
-        <option value={'student'}>{'Student'}</option>
+        <option value={'admin'}>{'Administrador '}</option>
+        <option value={'student'}>{'Estudante '}</option>
       </select>
       <SubmitButton onClick={submitSaveUser}>Salvar</SubmitButton>
     </Form>

--- a/src/lambda/graphql.js
+++ b/src/lambda/graphql.js
@@ -199,6 +199,7 @@ const resolvers = {
         )
         .then(() => true)
         .catch(() => false)
+      if (!success) throw Error('Erro ao salvar usuário')
       const user = await db.getUser(null, args.id)
       const userLogin = await db.getUser(null, `login#${args.input.login}`)
       return { success, user, userLogin }
@@ -209,6 +210,7 @@ const resolvers = {
         .editUserPassword(args.id, hashPassword(args.input.password))
         .then(() => true)
         .catch(() => false)
+      if (!success) throw Error('Erro ao salvar senha')
       return { success }
     },
     addUser: async (parent, args) => {


### PR DESCRIPTION
On editUserPage:
Changed the user type dropdown from Student and Admin to Estudante and Administrador respectively.

If the user edit fails a new toast message will appear:

![image](https://user-images.githubusercontent.com/70253649/114063592-2b4a1800-986f-11eb-94e2-15bc939d971f.png)

On browser console: 

![image](https://user-images.githubusercontent.com/70253649/114065123-b24bc000-9870-11eb-82fb-69a96f78bf6e.png)

On terminal: 

![image](https://user-images.githubusercontent.com/70253649/114065189-c2639f80-9870-11eb-9054-517473738ccd.png)

The error induced here was trying to change login into an already existing login, so using the terminal error you could track the third operation as seen in the error `[None, None, ConditionalCheckFailed]` and check which conditions the operation has.
