### PR TITLE
header no user fix

### DIFF
--- a/src/MenuPage/MenuPage.js
+++ b/src/MenuPage/MenuPage.js
@@ -34,7 +34,7 @@ export const MenuPage = ({ menu }) => {
   const { user } = useContext(CurrentUserContext)
   return (
     <Layout backgroundColor={colors.primary}>
-      <Header />
+      {user && <Header />}
       <Container>
         <Wrapper>
           {menu.elements.map(({ lesson }) => (

--- a/src/shared/Header/Header.js
+++ b/src/shared/Header/Header.js
@@ -14,10 +14,12 @@ export const Header = ({
   lessonIcon,
   adminPageActions,
 }) => {
-  const { user } = useContext(CurrentUserContext)
+  const { user, userLoading } = useContext(CurrentUserContext)
   const showAdminOnlyButtons =
     user && user.signedInUser.type === 'admin' ? true : false
-  return user ? (
+  return userLoading ? (
+    <Spinner />
+  ) : (
     <HeaderWrapper>
       {showAdminOnlyButtons && <MenuDrawer />}
       {title && <Title>{title}</Title>}
@@ -27,11 +29,13 @@ export const Header = ({
       {adminPageActions && showAdminOnlyButtons ? (
         <PageActions>{adminPageActions}</PageActions>
       ) : null}
-      <UserButtonWrapper>
-        <UserDrawer initial={user.initial} />
-      </UserButtonWrapper>
+      {user && (
+        <UserButtonWrapper>
+          <UserDrawer initial={user.initial} />
+        </UserButtonWrapper>
+      )}
     </HeaderWrapper>
-  ) : null
+  )
 }
 
 Header.propTypes = {


### PR DESCRIPTION
When no user is logged on the Menu page should now correctly hide the Header:

![image](https://user-images.githubusercontent.com/70253649/114073596-d8c22900-9879-11eb-9ded-94babdcdaca3.png)

And the viewLessonPage should now correctly show the Header:

![image](https://user-images.githubusercontent.com/70253649/114073703-f2fc0700-9879-11eb-8e24-df9e50c26597.png)
