### PR TITLE
menus listing with lessons img

### DIFF
--- a/src/MenusPage/ListItem/ListImages.js
+++ b/src/MenusPage/ListItem/ListImages.js
@@ -8,7 +8,7 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: flex-start;
   flex: 1;
-  @media (max-width: 500px) {
+  @media (max-width: 540px) {
     justify-content: center;
   }
 `
@@ -27,7 +27,7 @@ export const ListImages = ({ lessons }) => {
     remainingLessonsNumber && remainingLessonsNumber !== 0 ? true : false
 
   const windowWidthMedium = window.matchMedia('(max-width: 720px)')
-  const windowWidthSmall = window.matchMedia('(max-width: 500px)')
+  const windowWidthSmall = window.matchMedia('(max-width: 540px)')
   const windowWidthMobile = window.matchMedia('(max-width: 360px)')
 
   useEffect(() => {

--- a/src/MenusPage/ListItem/ListImages.js
+++ b/src/MenusPage/ListItem/ListImages.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react'
+import { RemainingLessons } from './RemainingLessons'
+import { LessonItem } from 'shared/LessonItem'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  flex: 1;
+  @media (max-width: 500px) {
+    justify-content: center;
+  }
+`
+
+export const ListImages = ({ lessons }) => {
+  const [numberOfLessons, setNumberOfLessons] = useState(null)
+
+  const remainingLessonsNumber =
+    numberOfLessons === 0
+      ? lessons.length
+      : lessons.length - numberOfLessons > 0
+      ? `+${lessons.length - numberOfLessons}`
+      : null
+
+  const showRemainingLessons =
+    remainingLessonsNumber && remainingLessonsNumber !== 0 ? true : false
+
+  const windowWidthMedium = window.matchMedia('(max-width: 720px)')
+  const windowWidthSmall = window.matchMedia('(max-width: 500px)')
+  const windowWidthMobile = window.matchMedia('(max-width: 360px)')
+
+  useEffect(() => {
+    if (windowWidthMobile.matches) {
+      setNumberOfLessons(0)
+    } else if (windowWidthSmall.matches) {
+      setNumberOfLessons(1)
+    } else if (windowWidthMedium.matches) {
+      setNumberOfLessons(2)
+    } else {
+      setNumberOfLessons(3)
+    }
+  }, [windowWidthSmall, windowWidthMedium, windowWidthMobile])
+
+  return (
+    <Wrapper>
+      {lessons.slice(0, numberOfLessons).map(({ lesson }) => (
+        <LessonItem
+          key={lesson.id}
+          image={lesson.image}
+          initials={lesson.initials}
+        />
+      ))}
+      <RemainingLessons
+        lessonNumber={remainingLessonsNumber}
+        showRemainingLessons={showRemainingLessons}
+      />
+    </Wrapper>
+  )
+}
+
+ListImages.propTypes = {
+  lessons: PropTypes.array,
+}

--- a/src/MenusPage/ListItem/ListItem.js
+++ b/src/MenusPage/ListItem/ListItem.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { useHistory } from 'react-router-dom'
 import { ListItemButton } from './ListItemButton'
 import { Wrapper, MenuName, MenuButtons } from './ListItem.styles'
-
+import { ListImages } from './ListImages'
 const navigateToViewMenu = (history, menuId) => (e) => {
   e.stopPropagation()
   history.push(`/viewMenu/${menuId}`)
@@ -20,6 +20,7 @@ export const ListItem = ({ menu }) => {
   return (
     <Wrapper onClick={navigateToEditMenu(history, menu.id)}>
       <MenuName>{menu.name}</MenuName>
+      <ListImages lessons={menu.elements} />
       &nbsp;&nbsp;
       <MenuButtons>
         <ListItemButton onClick={navigateToViewMenu(history, menu.id)} />

--- a/src/MenusPage/ListItem/ListItem.styles.js
+++ b/src/MenusPage/ListItem/ListItem.styles.js
@@ -15,6 +15,12 @@ export const MenuName = styled.div`
   align-items: center;
   margin-left: 2rem;
   flex: 1;
+  @media (max-width: 720px) {
+    margin-left: 1.5rem;
+  }
+  @media (max-width: 600px) {
+    margin-left: 1rem;
+  }
 `
 
 export const MenuButtons = styled.div`
@@ -22,4 +28,13 @@ export const MenuButtons = styled.div`
   display: flex;
   margin-right: 2rem;
   flex-direction: row-reverse;
+  @media (max-width: 720px) {
+    margin-right: 1.5rem;
+  }
+  @media (max-width: 600px) {
+    margin-right: 1rem;
+  }
+  @media (max-width: 400px) {
+    margin-right: 0;
+  }
 `

--- a/src/MenusPage/ListItem/RemainingLessons.js
+++ b/src/MenusPage/ListItem/RemainingLessons.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { colors } from 'shared/colors'
+
+const Wrapper = styled.div`
+  background-color: ${colors.white};
+  margin: 0.5rem 0.5rem 0.5rem 0px;
+  border: dashed 1px #999;
+  color: #655;
+  border-radius: 5px;
+  min-width: 3rem;
+  min-height: 3rem;
+  width: 3rem;
+  height: 3rem;
+  font-size: 1.5rem;
+  text-align: center;
+  font-family: Karla;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+export const RemainingLessons = ({ lessonNumber, showRemainingLessons }) => {
+  return <>{showRemainingLessons && <Wrapper>{lessonNumber}</Wrapper>}</>
+}
+
+RemainingLessons.propTypes = {
+  lessonNumber: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+  showRemainingLessons: PropTypes.bool,
+}

--- a/src/MenusPage/MENUS_QUERY.js
+++ b/src/MenusPage/MENUS_QUERY.js
@@ -5,6 +5,12 @@ export const MENUS_QUERY = gql`
     menus {
       id
       name
+      elements {
+        lesson {
+          image
+          initials
+        }
+      }
     }
   }
 `

--- a/src/shared/LessonItem.js
+++ b/src/shared/LessonItem.js
@@ -33,8 +33,8 @@ const ImageWrapper = styled.div`
 `
 const Img = styled.img`
   border-radius: 5px;
-  width: 3rem;
-  height: 3rem;
+  width: 2.9rem;
+  height: 2.9rem;
   object-fit: cover;
   margin: 0;
 `


### PR DESCRIPTION
Menus listing should now display lessons image/initials to a certain number (based on window width), the remaining lessons are displayed as a number.

In 720px width or higher:

![image](https://user-images.githubusercontent.com/70253649/114229483-4770b680-994e-11eb-9d58-1009be7ec50c.png)

In 720px ~ 540px width:

![image](https://user-images.githubusercontent.com/70253649/114229643-7d159f80-994e-11eb-8505-345b39e3c2bc.png)

In 360px ~ 540px width: 

![image](https://user-images.githubusercontent.com/70253649/114229704-961e5080-994e-11eb-8c01-9aa158600ab0.png)

In 359px or below:

![image](https://user-images.githubusercontent.com/70253649/114229767-a9c9b700-994e-11eb-949a-865b4af72571.png)
