### PR TITLE
margin in large screens

### DIFF
--- a/src/MenuPage/MenuPage.js
+++ b/src/MenuPage/MenuPage.js
@@ -16,6 +16,12 @@ const Wrapper = styled.div`
   justify-content: center;
   background-color: ${colors.primary};
   height: 100%;
+  margin-left: 20%;
+  margin-right: 20%;
+  @media (max-width: 720px) {
+    margin-right: 0;
+    margin-left: 0;
+  }
 `
 const IconWrapper = styled.div`
   margin-left: 0.5rem;

--- a/src/ViewLessonPage/ViewableElements/ElementWrapper.js
+++ b/src/ViewLessonPage/ViewableElements/ElementWrapper.js
@@ -2,6 +2,10 @@ import styled from 'styled-components'
 
 export const ElementWrapper = styled.div`
   margin-top: ${({ first }) => (first ? '15px' : '45px')};
-  margin-left: 25px;
-  margin-right: 25px;
+  margin-left: 25%;
+  margin-right: 25%;
+  @media (max-width: 720px) {
+    margin-left: 25px;
+    margin-right: 25px;
+  }
 `


### PR DESCRIPTION
Added big left/right margins on the menu page and lesson page on screens larger than 720px:

Menu:
![image](https://user-images.githubusercontent.com/70253649/114778813-b9c90880-9d4b-11eb-8818-eaed8f15b432.png)


Lesson: 
![image](https://user-images.githubusercontent.com/70253649/114779005-ec730100-9d4b-11eb-86c0-dc34289a7663.png)
