### PR TITLE
second iteration ItemsAndAudio

### DIFF
--- a/src/EditLessonPage/EditableLesson/EditableElements/AddElementButtons/emptyElementTemplates.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/AddElementButtons/emptyElementTemplates.js
@@ -31,7 +31,6 @@ export const emptyElementTemplates = {
   },
   ItemsAndAudios: {
     type: 'ItemsAndAudios',
-    audios: [],
     initialAudio: {},
     description: '',
     conclusionAudio: {},

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/ConclusionAudio/ConclusionAudio.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/ConclusionAudio/ConclusionAudio.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { TextAndInput } from '_shared/TextAndInput'
 import { DeleteConclusionAudioButton } from './DeleteConclusionAudioButton'
@@ -8,6 +8,7 @@ import { ConclusionAudioNameWrapper } from './ConclusionAudioNameWrapper'
 import { ConclusionAudioWrapper } from './ConclusionAudioWrapper'
 import { OptionalTextWrapper } from './OptionalTextWrapper'
 import { ConclusionAudioButtonsWrapper } from './ConclusionAudioButtonsWrapper'
+import { AddConclusionAudioButton } from './AddConclusionAudioButton'
 import {
   AudioButtonWrapper,
   AudioButtonMobileWrapper,
@@ -42,12 +43,20 @@ export const ConclusionAudio = ({
   changeConclusionAudio,
   audioFilePrefix,
 }) => {
+  const [showConclusionAudio, setShowConclusionAudio] = useState(false)
   const buildDeleteAudio = ({ changeConclusionAudio }) => () => {
     const newConclusionAudio = {}
     changeConclusionAudio(newConclusionAudio)
   }
   const [loading, setLoading] = useState(false)
 
+  useEffect(() => {
+    if (!conclusionAudio.name && !conclusionAudio.url)
+      setShowConclusionAudio(false)
+    else setShowConclusionAudio(true)
+  }, [conclusionAudio, setShowConclusionAudio])
+
+  const addConclusionAudio = () => setShowConclusionAudio(true)
   const AudioButtonBuilder = (size) => (
     <AudioButton
       audioUrls={[
@@ -63,7 +72,7 @@ export const ConclusionAudio = ({
       <OptionalTextWrapper>(Opcional)</OptionalTextWrapper>
       {loading ? (
         <Spinner />
-      ) : (
+      ) : showConclusionAudio ? (
         <ConclusionAudioButtonsWrapper>
           <DragAndDrop
             audioFilePrefix={audioFilePrefix}
@@ -105,6 +114,8 @@ export const ConclusionAudio = ({
             />
           </DragAndDrop>
         </ConclusionAudioButtonsWrapper>
+      ) : (
+        <AddConclusionAudioButton onClick={addConclusionAudio} />
       )}
     </ConclusionAudioWrapper>
   )

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/ElementParams.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/ElementParams.js
@@ -198,7 +198,7 @@ export const ElementParams = ({
 
           {showComponent(initialAudio) && (
             <ElementWrapper>
-              <ElementTitleWrapper>Instruções:</ElementTitleWrapper>
+              <ElementTitleWrapper>Áudio de antes:</ElementTitleWrapper>
               <InitialInstructions
                 initialAudio={initialAudio}
                 changeInitialAudio={changeInitialAudio}
@@ -274,7 +274,7 @@ export const ElementParams = ({
           )}
           {showComponent(conclusionAudio) && (
             <ElementWrapper>
-              <ElementTitleWrapper>Áudio de conclusão:</ElementTitleWrapper>
+              <ElementTitleWrapper>Áudio de depois:</ElementTitleWrapper>
               <ConclusionAudio
                 audioFilePrefix={`${lessonId}___`}
                 conclusionAudio={conclusionAudio}
@@ -295,7 +295,7 @@ ElementParams.propTypes = {
     type: PropTypes.string,
     letter: PropTypes.string,
     correctLetters: PropTypes.arrayOf(PropTypes.string),
-    items: PropTypes.arrayOf(PropTypes.string),
+    items: PropTypes.arrayOf(PropTypes.object),
     audios: PropTypes.arrayOf(
       PropTypes.shape({
         url: PropTypes.string.isRequired,

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/InitialInstructions/InitialInstructions.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/InitialInstructions/InitialInstructions.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { TextAndInput } from '_shared/TextAndInput'
 import { DeleteInitialAudioButton } from './DeleteInitialAudioButton'
@@ -9,6 +9,7 @@ import {
   InitialAudioNameWrapper,
   InitialAudioWrapper,
 } from './InitialInstructions.styles'
+import { AddInitialAudioButton } from './AddInitialAudioButton'
 import {
   AudioButtonWrapper,
   AudioButtonMobileWrapper,
@@ -41,6 +42,15 @@ export const InitialInstructions = ({
   changeInitialAudio,
   audioFilePrefix,
 }) => {
+  const [showInitialAudio, setShowInitialAudio] = useState(false)
+
+  useEffect(() => {
+    if (!initialAudio.name && !initialAudio.url) setShowInitialAudio(false)
+    else setShowInitialAudio(true)
+  }, [initialAudio, setShowInitialAudio])
+
+  const addInitialnAudio = () => setShowInitialAudio(true)
+
   const buildDeleteAudio = ({ changeInitialAudio }) => () => {
     const newInitialAudio = {}
     changeInitialAudio(newInitialAudio)
@@ -61,7 +71,7 @@ export const InitialInstructions = ({
     <InitialAudioWrapper>
       {loading ? (
         <Spinner />
-      ) : (
+      ) : showInitialAudio ? (
         <InitialAudioButtonsWrapper>
           <DragAndDrop
             audioFilePrefix={audioFilePrefix}
@@ -103,6 +113,8 @@ export const InitialInstructions = ({
             />
           </DragAndDrop>
         </InitialAudioButtonsWrapper>
+      ) : (
+        <AddInitialAudioButton onClick={addInitialnAudio} />
       )}
     </InitialAudioWrapper>
   )

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/InnerItem.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/InnerItem.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import { TextAndInput } from '_shared/TextAndInput'
+import { FileUploader } from '_shared/FileUploader'
+import { DragAndDrop } from '_shared/DragAndDrop'
+import { FileDownloader } from '../../FileDownloader'
+import { LessonItem } from '_shared/LessonItem'
+import { InnerItemWrapper, NameWrapper, LessonItemWrapper } from './Item.styles'
+import { colors } from '_shared/colors'
+import { DeleteItemButton } from './DeleteItemButton'
+import styled from 'styled-components'
+export const UploaderWrapper = styled.div`
+  display: flex;
+  margin-left: -12px;
+`
+export const InnerItem = ({
+  imageFilePrefix,
+  updateItem,
+  changeItem,
+  deleteItem,
+  item,
+}) => {
+  const IsImage =
+    item.endsWith('.png') || item.endsWith('.svg') || item.endsWith('.jpg')
+  const [loading, setLoading] = useState(false)
+  const [showImage, setShowImage] = useState(true)
+  const displayImage = IsImage && showImage
+
+  const toggleImage = () => {
+    setShowImage(!showImage)
+  }
+  return (
+    <DragAndDrop imageFilePrefix={imageFilePrefix} updateItemUrl={updateItem}>
+      <InnerItemWrapper>
+        <UploaderWrapper>
+          <FileUploader
+            color={colors.grayText}
+            loading={loading}
+            setLoading={setLoading}
+            imageFilePrefix={imageFilePrefix}
+            updateItem={updateItem}
+          />
+        </UploaderWrapper>
+        {IsImage && <FileDownloader color={colors.grayText} filename={item} />}
+        {displayImage ? (
+          <LessonItemWrapper>
+            <LessonItem
+              image={item}
+              color={colors.grayText}
+              onClick={toggleImage}
+            />
+          </LessonItemWrapper>
+        ) : IsImage && !showImage ? (
+          <NameWrapper>
+            <TextAndInput onChange={changeItem} color={colors.dimmedPrimary} />
+          </NameWrapper>
+        ) : null}
+        {!IsImage && (
+          <NameWrapper>
+            <TextAndInput
+              value={item}
+              onChange={changeItem}
+              color={colors.dimmedPrimary}
+            />
+          </NameWrapper>
+        )}
+        <DeleteItemButton deleteItem={deleteItem} />
+      </InnerItemWrapper>
+    </DragAndDrop>
+  )
+}
+
+InnerItem.propTypes = {
+  imageFilePrefix: PropTypes.string,
+  updateItem: PropTypes.func,
+  changeItem: PropTypes.func,
+  deleteItem: PropTypes.func,
+  item: PropTypes.string,
+}

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/Item.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/Item.js
@@ -1,85 +1,40 @@
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
-import { Spinner } from '_shared/Spinner'
-import { DeleteItemButton } from './DeleteItemButton'
-import { TextAndInput } from '_shared/TextAndInput'
-import { FileUploader } from '_shared/FileUploader'
-import { DragAndDrop } from '_shared/DragAndDrop'
-import { colors } from '_shared/colors'
-import { FileDownloader } from '../../FileDownloader'
-import { LessonItem } from '_shared/LessonItem'
-import { Wrapper, ItemWrapper, NameWrapper } from './Item.styles'
+import { Wrapper, ItemWrapper } from './Item.styles'
+import { ItemAudio } from './ItemAudio'
+import { InnerItem } from './InnerItem'
 
 export const Item = ({
   imageFilePrefix,
   item,
+  url,
   updateItem,
   deleteItem,
   changeItem,
 }) => {
-  const [loading, setLoading] = useState(false)
-  const [showImage, setShowImage] = useState(true)
-  const IsImage =
-    item.endsWith('.png') || item.endsWith('.svg') || item.endsWith('.jpg')
-
-  const displayImage = IsImage && showImage
-
-  const toggleImage = () => {
-    setShowImage(!showImage)
-  }
-
   return (
-    <ItemWrapper>
-      <DragAndDrop imageFilePrefix={imageFilePrefix} updateItem={updateItem}>
-        {loading ? (
-          <Spinner />
-        ) : (
-          <>
-            <FileUploader
-              color={colors.grayText}
-              loading={loading}
-              setLoading={setLoading}
-              imageFilePrefix={imageFilePrefix}
-              updateItem={updateItem}
-            />
-            {IsImage && (
-              <FileDownloader color={colors.grayText} filename={item} />
-            )}
-            {displayImage ? (
-              <Wrapper>
-                <LessonItem
-                  image={item}
-                  color={colors.grayText}
-                  onClick={toggleImage}
-                />
-              </Wrapper>
-            ) : IsImage && !showImage ? (
-              <NameWrapper>
-                <TextAndInput
-                  onChange={changeItem}
-                  color={colors.dimmedPrimary}
-                />
-              </NameWrapper>
-            ) : null}
-            {!IsImage && (
-              <NameWrapper>
-                <TextAndInput
-                  value={item}
-                  onChange={changeItem}
-                  color={colors.dimmedPrimary}
-                />
-              </NameWrapper>
-            )}
-            <DeleteItemButton deleteItem={deleteItem} />
-          </>
-        )}
-      </DragAndDrop>
-    </ItemWrapper>
+    <Wrapper>
+      <ItemWrapper>
+        <ItemAudio
+          updateItem={updateItem}
+          url={url}
+          audioFilePrefix={imageFilePrefix}
+        />
+        <InnerItem
+          imageFilePrefix={imageFilePrefix}
+          updateItem={updateItem}
+          changeItem={changeItem}
+          deleteItem={deleteItem}
+          item={item}
+        />
+      </ItemWrapper>
+    </Wrapper>
   )
 }
 
 Item.propTypes = {
   imageFilePrefix: PropTypes.string,
+  url: PropTypes.string,
   item: PropTypes.string,
   updateItem: PropTypes.func,
   deleteItem: PropTypes.func,

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/Item.styles.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/Item.styles.js
@@ -1,15 +1,16 @@
 import styled from 'styled-components'
+import { colors } from '_shared/colors'
 
-export const Wrapper = styled.div`
+export const LessonItemWrapper = styled.div`
   width: 100%;
   padding-left: 8px;
 `
 
-export const ItemWrapper = styled.div`
+export const Wrapper = styled.div`
   min-height: 4rem;
   display: flex;
   align-self: center;
-  padding-left: 24px;
+  border-bottom: solid 1px ${colors.light};
 `
 
 export const NameWrapper = styled.div`
@@ -17,4 +18,20 @@ export const NameWrapper = styled.div`
   align-self: center;
   width: 100%;
   padding-left: 8px;
+`
+
+export const AudioButtonsWrapper = styled.div`
+  padding-top: 10px;
+  display: flex;
+`
+export const ItemWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`
+export const InnerItemWrapper = styled.div`
+  display: flex;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  width: 100%;
 `

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/ItemAudio.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/ItemAudio.js
@@ -1,0 +1,39 @@
+import React, { useState } from 'react'
+import { DragAndDrop } from '_shared/DragAndDrop'
+import { FileUploader } from '_shared/FileUploader'
+import { AudioButtonsWrapper } from './Item.styles'
+import { AudioButton } from '_shared/AudioButton'
+import PropTypes from 'prop-types'
+import { FileDownloader } from '../../FileDownloader'
+import { colors } from '_shared/colors'
+
+export const ItemAudio = ({ audioFilePrefix, updateItem, url }) => {
+  const [loading, setLoading] = useState(false)
+  return (
+    <DragAndDrop audioFilePrefix={audioFilePrefix} updateItemUrl={updateItem}>
+      <AudioButtonsWrapper>
+        <AudioButton
+          audioUrls={[
+            `https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${url}`,
+          ]}
+          color={colors.grayText}
+          size={20}
+        />
+        <FileUploader
+          color={colors.grayText}
+          loading={loading}
+          setLoading={setLoading}
+          audioFilePrefix={audioFilePrefix}
+          updateItemUrl={updateItem}
+        />
+        <FileDownloader color={colors.grayText} filename={url} />
+      </AudioButtonsWrapper>
+    </DragAndDrop>
+  )
+}
+
+ItemAudio.propTypes = {
+  audioFilePrefix: PropTypes.string,
+  url: PropTypes.string,
+  updateItem: PropTypes.func,
+}

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Items.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Items.js
@@ -5,7 +5,10 @@ import { AddItemButton } from './AddItemButton'
 
 const buildUpdateItem = ({ items, itemIndex, changeItems }) => (payload) => {
   const newItems = [...items]
-  newItems[itemIndex] = payload
+  newItems[itemIndex] = {
+    ...items[itemIndex],
+    ...payload,
+  }
   changeItems(newItems)
 }
 
@@ -17,18 +20,21 @@ const buildDeleteItem = ({ items, itemIndex, changeItems }) => () => {
 
 const buildChangeItem = ({ items, itemIndex, changeItems }) => (item) => {
   const newItems = [...items]
-  newItems[itemIndex] = item
+  newItems[itemIndex] = {
+    ...newItems[itemIndex],
+    item,
+  }
 
   changeItems(newItems)
 }
 
 export const Items = ({ items, changeItems, imageFilePrefix }) => {
-  const addItem = () => changeItems([...items, ''])
+  const addItem = () => changeItems([...items, { item: '', url: '' }])
 
   return (
     <>
       {items &&
-        items.map((item, itemIndex) => (
+        items.map(({ item, url }, itemIndex) => (
           <Item
             imageFilePrefix={imageFilePrefix}
             index={itemIndex}
@@ -44,6 +50,7 @@ export const Items = ({ items, changeItems, imageFilePrefix }) => {
             })}
             changeItem={buildChangeItem({ items, itemIndex, changeItems })}
             item={item}
+            url={url}
             key={itemIndex}
           />
         ))}
@@ -54,6 +61,6 @@ export const Items = ({ items, changeItems, imageFilePrefix }) => {
 
 Items.propTypes = {
   imageFilePrefix: PropTypes.string,
-  items: PropTypes.arrayOf(PropTypes.string),
+  items: PropTypes.arrayOf(PropTypes.object),
   changeItems: PropTypes.func,
 }

--- a/src/_shared/DragAndDrop.js
+++ b/src/_shared/DragAndDrop.js
@@ -73,6 +73,7 @@ export const DragAndDrop = ({
   updateRightAnswerAudio,
   updateWrongAnswerAudio,
   updateItem,
+  updateItemUrl,
   videoFilePrefix,
   imageFilePrefix,
   setImageUrl,
@@ -124,7 +125,8 @@ export const DragAndDrop = ({
           })
         else if (setImageUrl) setImageUrl(filename)
         else if (setMenuImage) setMenuImage(filename)
-        else if (updateItem) updateItem(filename)
+        else if (updateItem) updateItem({ item: filename })
+        else if (updateItemUrl) updateItem({ url: filename })
       }
 
       reader.addEventListener(
@@ -151,6 +153,7 @@ export const DragAndDrop = ({
       imageFilePrefix,
       setImageUrl,
       setMenuImage,
+      updateItemUrl,
     ]
   )
 
@@ -239,4 +242,5 @@ DragAndDrop.propTypes = {
   updateVideo: PropTypes.func,
   imageFilePrefix: PropTypes.string,
   setImageUrl: PropTypes.func,
+  updateItemUrl: PropTypes.func,
 }

--- a/src/_shared/Element/Element.js
+++ b/src/_shared/Element/Element.js
@@ -80,7 +80,6 @@ export const Element = ({ elementParams, actual, onComplete }) => {
         <ItemsAndAudiosElement
           onComplete={onComplete}
           actual={actual}
-          audios={audios}
           items={items}
           initialAudio={initialAudio}
           conclusionAudio={conclusionAudio}

--- a/src/_shared/Element/addBucketPrefixesToElementParams.js
+++ b/src/_shared/Element/addBucketPrefixesToElementParams.js
@@ -10,16 +10,24 @@ const addBucketPrefixToWords = (words) =>
     urlWrongAnswerExplanation: addBucketPrefix(word.urlWrongAnswerExplanation),
   }))
 
+const addBucketPrefixToItems = (items) =>
+  items.map((item) => ({
+    ...item,
+    url: addBucketPrefix(item.url),
+  }))
+
 export const addBucketPrefixesToElementParams = (elementParams) => {
   const {
     audioUrls,
     urlVideo,
     words,
+    items,
     conclusionAudio,
     initialAudio,
   } = elementParams
   const fullUrlWords = words && addBucketPrefixToWords(words)
   const fullAudioUrls = audioUrls && audioUrls.map(addBucketPrefix)
+  const fullUrlItems = items && addBucketPrefixToItems(items)
   const fullUrlVideo = urlVideo && urlVideo.map(addBucketPrefix)
   const fullUrlConclusionAudio =
     conclusionAudio && addBucketPrefix(conclusionAudio.url)
@@ -46,5 +54,6 @@ export const addBucketPrefixesToElementParams = (elementParams) => {
     words: fullUrlWords,
     conclusionAudio: newConclusionAudio,
     initialAudio: newInitialAudio,
+    items: fullUrlItems,
   }
 }

--- a/src/_shared/FileUploader.js
+++ b/src/_shared/FileUploader.js
@@ -58,6 +58,7 @@ export const FileUploader = ({
   updateWrongAnswerAudio,
   updateAudio,
   updateItem,
+  updateItemUrl,
   videoFilePrefix,
   imageFilePrefix,
   setImageUrl,
@@ -112,7 +113,8 @@ export const FileUploader = ({
           })
         else if (setImageUrl) setImageUrl(filename)
         else if (setMenuImage) setMenuImage(filename)
-        else if (updateItem) updateItem(filename)
+        else if (updateItem) updateItem({ item: filename })
+        else if (updateItemUrl) updateItem({ url: filename })
       }
       reader.addEventListener(
         'loadend',
@@ -139,6 +141,7 @@ export const FileUploader = ({
       setLoading,
       setImageUrl,
       setMenuImage,
+      updateItemUrl,
     ]
   )
   return (
@@ -181,4 +184,5 @@ FileUploader.propTypes = {
   updateVideo: PropTypes.func,
   imageFilePrefix: PropTypes.string,
   setImageUrl: PropTypes.func,
+  updateItemUrl: PropTypes.func,
 }

--- a/src/_shared/ItemsAndAudiosElement/Items.js
+++ b/src/_shared/ItemsAndAudiosElement/Items.js
@@ -17,11 +17,12 @@ const Img = styled.img`
 `
 
 export const Items = ({ children }) => {
-  const IsImage = children
-    ? children.endsWith('.png') ||
-      children.endsWith('.svg') ||
-      children.endsWith('.jpg')
-    : null
+  const IsImage =
+    children && children.item
+      ? children.item.endsWith('.png') ||
+        children.item.endsWith('.svg') ||
+        children.item.endsWith('.jpg')
+      : null
   const textRef = useRef()
   const [width, setWidth] = useState(null)
   useEffect(() => {
@@ -42,13 +43,13 @@ export const Items = ({ children }) => {
             y="140"
             fontSize={150}
           >
-            {children}
+            {children && children.item}
           </text>
         </svg>
       )}
       {IsImage && (
         <Img
-          src={`https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${children}`}
+          src={`https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${children.item}`}
         />
       )}
     </Wrapper>
@@ -56,5 +57,5 @@ export const Items = ({ children }) => {
 }
 
 Items.propTypes = {
-  children: PropTypes.string,
+  children: PropTypes.object,
 }

--- a/src/_shared/ItemsAndAudiosElement/ItemsAndAudiosElement.js
+++ b/src/_shared/ItemsAndAudiosElement/ItemsAndAudiosElement.js
@@ -16,7 +16,6 @@ const AudioButton = loadable(async () => {
 
 export const ItemsAndAudiosElement = ({
   items,
-  audios,
   actual,
   onComplete,
   initialAudio,
@@ -61,11 +60,13 @@ export const ItemsAndAudiosElement = ({
   return (
     <Card first complete={complete}>
       <CenterWrapper>
-        <AudioButton
-          color={actual && !instructionsCompleted ? colors.actual : null}
-          onComplete={setInstructionsCompleted}
-          audioUrls={initialAudio && [initialAudio.url]}
-        />
+        {initialAudio.url && (
+          <AudioButton
+            color={actual && !instructionsCompleted ? colors.actual : null}
+            onComplete={setInstructionsCompleted}
+            audioUrls={initialAudio && [initialAudio.url]}
+          />
+        )}
         <Items>{actualItem}</Items>
         <PlayButtonWrapper>
           <AudioButton
@@ -74,7 +75,7 @@ export const ItemsAndAudiosElement = ({
             color={actual && !exerciseCompleted ? colors.actual : null}
             disabled={end}
             icon="Play"
-            audioUrls={audios.map(({ url }) => url)}
+            audioUrls={items.map(({ url }) => url)}
             width={20}
             onStepComplete={setListened}
           />
@@ -92,7 +93,7 @@ export const ItemsAndAudiosElement = ({
 }
 
 ItemsAndAudiosElement.propTypes = {
-  items: PropTypes.arrayOf(PropTypes.string),
+  items: PropTypes.arrayOf(PropTypes.object),
   audios: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,

--- a/src/_shared/LESSON_QUERY.js
+++ b/src/_shared/LESSON_QUERY.js
@@ -10,7 +10,10 @@ export const LESSON_QUERY = gql`
       elements {
         type
         letter
-        items
+        items {
+          item
+          url
+        }
         correctLetters
         audioUrls
         audios {

--- a/src/_shared/mapLesson.js
+++ b/src/_shared/mapLesson.js
@@ -20,15 +20,8 @@ const mappers = {
     return { type, audios, description, correctLetters, text }
   },
   ItemsAndAudios: (el) => {
-    const {
-      type,
-      audios,
-      description,
-      initialAudio,
-      conclusionAudio,
-      items,
-    } = el
-    return { type, audios, description, initialAudio, conclusionAudio, items }
+    const { type, description, initialAudio, conclusionAudio, items } = el
+    return { type, description, initialAudio, conclusionAudio, items }
   },
 }
 

--- a/src/lambda/graphql/typeDefs.js
+++ b/src/lambda/graphql/typeDefs.js
@@ -36,10 +36,15 @@ export default gql`
     url: String
   }
 
+  type Item {
+    item: String
+    url: String
+  }
+
   type Element {
     type: String!
     letter: String
-    items: [String]
+    items: [Item]
     correctLetters: [String]
     audioUrls: [String]
     audios: [Audio]
@@ -167,6 +172,11 @@ export default gql`
     url: String
   }
 
+  input ItemInput {
+    item: String
+    url: String
+  }
+
   input ElementLessonInput {
     type: String
     letter: String
@@ -174,7 +184,7 @@ export default gql`
     audioUrls: [String]
     audios: [AudioInput]
     urlVideo: [String]
-    items: [String]
+    items: [ItemInput]
     videos: [VideoInput]
     description: String
     text: String


### PR DESCRIPTION
If there is no initialAudio or conclusionAudio their respective audio button should no longer display.

Changed items to now be an object that contains item and url, as in, ` {item: string, url: string} `.

Changed the edit section of items to improve user experience.