### PR TITLE
trail dots / play button

### DIFF
--- a/src/_shared/AudioButton/AudioButton.js
+++ b/src/_shared/AudioButton/AudioButton.js
@@ -5,11 +5,12 @@ import { useMedia } from '../useMedia'
 import { Wrapper } from './Wrapper'
 import { TrailDot } from './TrailDot'
 import { colors } from '../colors'
+import { DotWrapper } from './DotWrapper'
 
 export const AudioButton = ({
   audioUrls,
   size,
-  icon = 'Speaker',
+  icon,
   onClick,
   onStart,
   onComplete,
@@ -18,6 +19,7 @@ export const AudioButton = ({
   disabled,
   color,
   playingColor,
+  showDots,
 }) => {
   if (!color) color = colors.ready
   if (!playingColor) playingColor = colors.playing
@@ -73,18 +75,22 @@ export const AudioButton = ({
   const content = <Icon shape={icon} color={showColor} size={size} />
 
   const empty = audioUrls.length === 0
-  const numDotsBefore = empty ? 0 : actualItem
-  const numDotsAfter = empty ? 0 : audioUrls.length - actualItem - 1
+  // const numDotsBefore = empty ? 0 : actualItem
+  // const numDotsAfter = empty ? 0 : audioUrls.length - actualItem - 1
+  const numOfDots = empty ? 0 : audioUrls.length
+  const dotColor = (i) => (i === actualItem ? color : colors.ready)
+  const showDot = showDots && audioUrls[0]
 
   return (
     <Wrapper onClick={playIfEnabled} disabled={disabled}>
-      {[...Array(numDotsBefore)].map((n, i) => (
-        <TrailDot key={i} color={color} />
-      ))}
+      {showDot && (
+        <DotWrapper>
+          {[...Array(numOfDots)].map((n, i) => (
+            <TrailDot key={i} color={dotColor(i)} />
+          ))}
+        </DotWrapper>
+      )}
       {content}
-      {[...Array(numDotsAfter)].map((n, i) => (
-        <TrailDot key={i} color={color} />
-      ))}
     </Wrapper>
   )
 }
@@ -103,4 +109,5 @@ AudioButton.propTypes = {
   playingColor: PropTypes.string,
   beforeTrailCount: PropTypes.number,
   afterTrailCount: PropTypes.number,
+  showDots: PropTypes.bool,
 }

--- a/src/_shared/AudioButton/DotWrapper.js
+++ b/src/_shared/AudioButton/DotWrapper.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+export const DotWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: -25px;
+  padding-bottom: 5px;
+`

--- a/src/_shared/AudioButton/Wrapper.js
+++ b/src/_shared/AudioButton/Wrapper.js
@@ -4,4 +4,5 @@ export const Wrapper = styled.div`
   cursor: ${({ disabled }) => (disabled ? null : 'pointer')};
   display: flex;
   align-items: center;
+  flex-direction: column;
 `

--- a/src/_shared/AudioElement/AudioElement.js
+++ b/src/_shared/AudioElement/AudioElement.js
@@ -24,6 +24,7 @@ export const AudioElement = ({ audios, actual, onComplete }) => {
             color={actual ? colors.actual : null}
             onComplete={doComplete}
             audioUrls={audios.map(({ url }) => url)}
+            showDots={true}
           />
         </InnerWrapper>
       </Wrapper>

--- a/src/_shared/CheckFirstLetter/CheckFirstLetter.js
+++ b/src/_shared/CheckFirstLetter/CheckFirstLetter.js
@@ -94,6 +94,7 @@ export const CheckFirstLetter = ({
           loop={true}
           color={actual && !instructionsCompleted ? colors.actual : null}
           onComplete={setInstructionsCompleted}
+          showDots={true}
         />
         {state.showYesIcon && <Icon shape="ThumbsUp" />}
         {state.showNoIcon && <Icon shape="ThumbsDown" />}
@@ -115,6 +116,7 @@ export const CheckFirstLetter = ({
             audioUrls={[urlWord]}
             width={20}
             onComplete={setListened}
+            showDots={true}
           />
         )}
         <SimpleAudio

--- a/src/_shared/ClickLetterInTheTextTaskElement/ClickLetterInTheTextTaskElement.js
+++ b/src/_shared/ClickLetterInTheTextTaskElement/ClickLetterInTheTextTaskElement.js
@@ -35,6 +35,7 @@ export const ClickLetterInTheTextTaskElement = ({
             color={!audioIsListened && actual ? colors.actual : null}
             onComplete={setListened}
             audioUrls={audios.map(({ url }) => url)}
+            showDots={true}
           />
         </ItemWrapper>
         <ItemWrapper>

--- a/src/_shared/ClickWordStartingWithALetterInTheTextTaskElement/ClickWordStartingWithALetterInTheTextTaskElement.js
+++ b/src/_shared/ClickWordStartingWithALetterInTheTextTaskElement/ClickWordStartingWithALetterInTheTextTaskElement.js
@@ -44,6 +44,7 @@ export const ClickWordStartingWithALetterInTheTextTaskElement = ({
             color={!audioIsListened && actual ? colors.actual : colors.ready}
             onComplete={setListened}
             audioUrls={audios.map(({ url }) => url)}
+            showDots={true}
           />
         </ItemWrapper>
         <ItemWrapper>

--- a/src/_shared/ItemsAndAudiosElement/ItemsAndAudiosElement.js
+++ b/src/_shared/ItemsAndAudiosElement/ItemsAndAudiosElement.js
@@ -78,6 +78,7 @@ export const ItemsAndAudiosElement = ({
             audioUrls={items.map(({ url }) => url)}
             width={20}
             onStepComplete={setListened}
+            showDots={true}
           />
         </PlayButtonWrapper>
         {conclusionAudio.url && (

--- a/src/_shared/LetterAndAudioElement/LetterAndAudioElement.js
+++ b/src/_shared/LetterAndAudioElement/LetterAndAudioElement.js
@@ -30,6 +30,7 @@ export const LetterAndAudioElement = ({
             color={actual ? colors.actual : null}
             onComplete={doComplete}
             audioUrls={audios.map(({ url }) => url)}
+            showDots={true}
           />
         </InnerWrapper>
       </CenterWrapper>


### PR DESCRIPTION
First steps of the issue (https://github.com/ReisTecnologia/abc/issues/201):

All audio buttons are now play buttons
![image](https://user-images.githubusercontent.com/70253649/116280436-0b678f00-a75f-11eb-964f-bfda8905fdea.png)


The dots representing the number of audios are now on top of the play buttons and the specific dot gets colored:

![image](https://user-images.githubusercontent.com/70253649/116280681-541f4800-a75f-11eb-95ed-c4e1ecb06dc8.png)

Only after the audio is complete the next dot gets lit up:

![image](https://user-images.githubusercontent.com/70253649/116280750-639e9100-a75f-11eb-93db-462c421379ca.png)
