### PR TITLE
paywall first iteration

### DIFF
--- a/src/EditMenuPage/EditableMenu/EditableMenu.js
+++ b/src/EditMenuPage/EditableMenu/EditableMenu.js
@@ -78,7 +78,10 @@ export const EditableMenu = ({
   }
 
   const addLesson = (lessonId) =>
-    setInnerElements([...innerElements, { lessonId: lessonId }])
+    setInnerElements([
+      ...innerElements,
+      { lessonId: lessonId, freeLesson: false },
+    ])
 
   useEffect(() => {
     if (!isFirstRun.current) {

--- a/src/MenuPage/FreeMenu.js
+++ b/src/MenuPage/FreeMenu.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { LessonItem } from '_shared/LessonItem'
+import {
+  Wrapper,
+  IconWrapper,
+  IconAndNameWrapper,
+  LessonNameWrapper,
+  FreeMenuWrapper,
+  PaidLessonsOverlay,
+} from './MenuPage.styles'
+import { Link } from 'react-router-dom'
+import { PayWall } from './PayWall'
+
+export const FreeMenu = ({ menu, showFullMenu }) => {
+  const freeLessons = menu.elements.filter(
+    (element) => element.freeLesson === true
+  )
+  const paidLessons = menu.elements.filter(
+    (element) => element.freeLesson === false
+  )
+  return (
+    <>
+      {!showFullMenu && (
+        <FreeMenuWrapper>
+          <Wrapper>
+            {freeLessons.map(({ lesson }) => (
+              <Link
+                key={lesson.id}
+                to={`/viewLesson/${lesson.id}?menuId=${menu.id}`}
+              >
+                <IconAndNameWrapper>
+                  <IconWrapper>
+                    <LessonItem
+                      initials={lesson.initials}
+                      image={lesson.image}
+                    />
+                  </IconWrapper>
+                  <LessonNameWrapper>{lesson.name}</LessonNameWrapper>
+                </IconAndNameWrapper>
+              </Link>
+            ))}
+          </Wrapper>
+          <PayWall />
+          <PaidLessonsOverlay>
+            <Wrapper>
+              {paidLessons.map(({ lesson }) => (
+                <Link
+                  key={lesson.id}
+                  to={`/viewLesson/${lesson.id}?menuId=${menu.id}`}
+                >
+                  <IconAndNameWrapper>
+                    <IconWrapper>
+                      <LessonItem
+                        initials={lesson.initials}
+                        image={lesson.image}
+                      />
+                    </IconWrapper>
+                    <LessonNameWrapper>{lesson.name}</LessonNameWrapper>
+                  </IconAndNameWrapper>
+                </Link>
+              ))}
+            </Wrapper>
+          </PaidLessonsOverlay>
+        </FreeMenuWrapper>
+      )}
+    </>
+  )
+}
+
+FreeMenu.propTypes = {
+  showFullMenu: PropTypes.bool,
+  menu: PropTypes.object,
+}

--- a/src/MenuPage/FullMenu.js
+++ b/src/MenuPage/FullMenu.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { LessonItem } from '_shared/LessonItem'
+import {
+  Wrapper,
+  IconWrapper,
+  IconAndNameWrapper,
+  LessonNameWrapper,
+} from './MenuPage.styles'
+import { Link } from 'react-router-dom'
+
+export const FullMenu = ({ menu, showFullMenu }) => {
+  return (
+    <>
+      {showFullMenu && (
+        <Wrapper>
+          {menu.elements.map(({ lesson }) => (
+            <>
+              <Link
+                key={lesson.id}
+                to={`/viewLesson/${lesson.id}?menuId=${menu.id}`}
+              >
+                <IconAndNameWrapper>
+                  <IconWrapper>
+                    <LessonItem
+                      initials={lesson.initials}
+                      image={lesson.image}
+                    />
+                  </IconWrapper>
+                  <LessonNameWrapper>{lesson.name}</LessonNameWrapper>
+                </IconAndNameWrapper>
+              </Link>
+            </>
+          ))}
+        </Wrapper>
+      )}
+    </>
+  )
+}
+
+FullMenu.propTypes = {
+  menu: PropTypes.object,
+  showFullMenu: PropTypes.bool,
+}

--- a/src/MenuPage/MENU_QUERY.js
+++ b/src/MenuPage/MENU_QUERY.js
@@ -7,6 +7,7 @@ export const MENU_QUERY = gql`
       name
       backgroundImage
       elements {
+        freeLesson
         lessonId
         lesson {
           name

--- a/src/MenuPage/MenuPage.js
+++ b/src/MenuPage/MenuPage.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { LessonItem } from '_shared/LessonItem'
 import { Layout } from '_shared/Layout'
@@ -11,43 +11,55 @@ import {
 import { colors } from '_shared/colors'
 import { Link } from 'react-router-dom'
 import { Container } from '_shared/Container'
-import { CurrentUserContext } from '_shared/CurrentUserContextProvider'
 import { Header } from '_shared/Header/Header'
 import { SignInOrOutButton } from './SignInOrOutButton'
 
-export const MenuPage = ({ menu }) => {
-  const { user } = useContext(CurrentUserContext)
+export const MenuPage = ({ menu, user }) => {
+  const menuIsPurchased =
+    user && user.signedInUser.paidMenus.map((menu) => menu.id).includes(menu.id)
+  const userIsAdmin = user && user.signedInUser.type === 'admin'
+  const showFullMenu = userIsAdmin || menuIsPurchased
   const backgroundImgUrl = `https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${menu.backgroundImage}`
   return (
-    <Layout backgroundColor={colors.primary} backgroundImage={backgroundImgUrl}>
-      {user && <Header />}
-      <Container>
-        <Wrapper>
-          {menu.elements.map(({ lesson }) => (
-            <>
-              <Link
-                key={lesson.id}
-                to={`/viewLesson/${lesson.id}?menuId=${menu.id}`}
-              >
-                <IconAndNameWrapper>
-                  <IconWrapper>
-                    <LessonItem
-                      initials={lesson.initials}
-                      image={lesson.image}
-                    />
-                  </IconWrapper>
-                  <LessonNameWrapper>{lesson.name}</LessonNameWrapper>
-                </IconAndNameWrapper>
-              </Link>
-            </>
-          ))}
-        </Wrapper>
-        <SignInOrOutButton showLogoutButton={!!user} />
-      </Container>
-    </Layout>
+    <>
+      {showFullMenu ? (
+        <Layout
+          backgroundColor={colors.primary}
+          backgroundImage={backgroundImgUrl}
+        >
+          {user && <Header />}
+          <Container>
+            <Wrapper>
+              {menu.elements.map(({ lesson }) => (
+                <>
+                  <Link
+                    key={lesson.id}
+                    to={`/viewLesson/${lesson.id}?menuId=${menu.id}`}
+                  >
+                    <IconAndNameWrapper>
+                      <IconWrapper>
+                        <LessonItem
+                          initials={lesson.initials}
+                          image={lesson.image}
+                        />
+                      </IconWrapper>
+                      <LessonNameWrapper>{lesson.name}</LessonNameWrapper>
+                    </IconAndNameWrapper>
+                  </Link>
+                </>
+              ))}
+            </Wrapper>
+            <SignInOrOutButton showLogoutButton={!!user} />
+          </Container>
+        </Layout>
+      ) : (
+        <span>Você não comprou esse menu</span>
+      )}
+    </>
   )
 }
 
 MenuPage.propTypes = {
   menu: PropTypes.object.isRequired,
+  user: PropTypes.object.isRequired,
 }

--- a/src/MenuPage/MenuPage.js
+++ b/src/MenuPage/MenuPage.js
@@ -1,18 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { LessonItem } from '_shared/LessonItem'
 import { Layout } from '_shared/Layout'
-import {
-  Wrapper,
-  IconWrapper,
-  IconAndNameWrapper,
-  LessonNameWrapper,
-} from './MenuPage.styles'
 import { colors } from '_shared/colors'
-import { Link } from 'react-router-dom'
 import { Container } from '_shared/Container'
 import { Header } from '_shared/Header/Header'
 import { SignInOrOutButton } from './SignInOrOutButton'
+import { FullMenu } from './FullMenu'
+import { FreeMenu } from './FreeMenu'
 
 export const MenuPage = ({ menu, user }) => {
   const menuIsPurchased =
@@ -20,41 +14,20 @@ export const MenuPage = ({ menu, user }) => {
   const userIsAdmin = user && user.signedInUser.type === 'admin'
   const showFullMenu = userIsAdmin || menuIsPurchased
   const backgroundImgUrl = `https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${menu.backgroundImage}`
+
   return (
     <>
-      {showFullMenu ? (
-        <Layout
-          backgroundColor={colors.primary}
-          backgroundImage={backgroundImgUrl}
-        >
-          {user && <Header />}
-          <Container>
-            <Wrapper>
-              {menu.elements.map(({ lesson }) => (
-                <>
-                  <Link
-                    key={lesson.id}
-                    to={`/viewLesson/${lesson.id}?menuId=${menu.id}`}
-                  >
-                    <IconAndNameWrapper>
-                      <IconWrapper>
-                        <LessonItem
-                          initials={lesson.initials}
-                          image={lesson.image}
-                        />
-                      </IconWrapper>
-                      <LessonNameWrapper>{lesson.name}</LessonNameWrapper>
-                    </IconAndNameWrapper>
-                  </Link>
-                </>
-              ))}
-            </Wrapper>
-            <SignInOrOutButton showLogoutButton={!!user} />
-          </Container>
-        </Layout>
-      ) : (
-        <span>Você não comprou esse menu</span>
-      )}
+      <Layout
+        backgroundColor={colors.primary}
+        backgroundImage={backgroundImgUrl}
+      >
+        {user && <Header />}
+        <Container>
+          <FullMenu menu={menu} showFullMenu={showFullMenu} />
+          <FreeMenu menu={menu} showFullMenu={showFullMenu} />
+          <SignInOrOutButton showLogoutButton={!!user} />
+        </Container>
+      </Layout>
     </>
   )
 }

--- a/src/MenuPage/MenuPage.styles.js
+++ b/src/MenuPage/MenuPage.styles.js
@@ -12,6 +12,13 @@ export const Wrapper = styled.div`
     margin-left: 0;
   }
 `
+export const PaidLessonsOverlay = styled.div`
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  opacity: 0.5;
+  pointer-events: none;
+`
 export const IconWrapper = styled.div`
   margin-left: 0.5rem;
 `
@@ -26,4 +33,8 @@ export const LessonNameWrapper = styled.div`
   color: white;
   text-align: center;
   font-size: 13px;
+`
+export const FreeMenuWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
 `

--- a/src/MenuPage/PayWall.js
+++ b/src/MenuPage/PayWall.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import styled from 'styled-components'
+import { colors } from '_shared/colors'
+
+const PaywallWrapper = styled.div`
+  width: 100%;
+  height: 200px;
+  background-color: ${colors.dimmedPrimary};
+  text-align: center;
+  color: white;
+`
+
+export const PayWall = () => {
+  return <PaywallWrapper>Paywall</PaywallWrapper>
+}

--- a/src/MenuPage/ViewMenuLoader.js
+++ b/src/MenuPage/ViewMenuLoader.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { useQuery } from '@apollo/client'
 import { MENU_QUERY } from './MENU_QUERY'
 import { MenuPage } from './MenuPage'
@@ -6,10 +6,13 @@ import { useParams } from 'react-router-dom'
 import { Spinner } from '_shared/Spinner'
 import { Layout } from '_shared/Layout'
 import { colors } from '_shared/colors'
+import { CurrentUserContext } from '_shared/CurrentUserContextProvider'
 
 const DEFAULT_MENU_ID = 'main'
 
 export const ViewMenuLoader = () => {
+  const { user } = useContext(CurrentUserContext)
+
   let { menuId } = useParams()
 
   const { data, loading: loadingMenu, error } = useQuery(MENU_QUERY, {
@@ -26,6 +29,6 @@ export const ViewMenuLoader = () => {
       <Spinner />
     </Layout>
   ) : data && data.menu ? (
-    <MenuPage menu={data.menu} />
+    <MenuPage menu={data.menu} user={user} />
   ) : null
 }

--- a/src/SignInPage/ForgotPasswordForm/ForgotPassword.js
+++ b/src/SignInPage/ForgotPasswordForm/ForgotPassword.js
@@ -76,7 +76,7 @@ export const ForgotPassword = () => {
         <Spinner />
       ) : !data ? (
         <Form>
-          <Label>Ensira seu usuário ou email:</Label>
+          <Label>Insira seu usuário ou email:</Label>
           <input
             type="text"
             id="login"

--- a/src/UsersPage/AddUserButton/AddUserButton.js
+++ b/src/UsersPage/AddUserButton/AddUserButton.js
@@ -27,6 +27,7 @@ export const AddUserButton = ({ afterAdd }) => {
         login: 'usuario',
         password: '123',
         email: 'exemplo@email.com',
+        paidMenus: [],
       },
     },
   })

--- a/src/ViewLessonPage/MENU_QUERY.js
+++ b/src/ViewLessonPage/MENU_QUERY.js
@@ -4,6 +4,10 @@ export const MENU_QUERY = gql`
   query($id: String!) {
     menu(id: $id) {
       backgroundImage
+      elements {
+        freeLesson
+        lessonId
+      }
     }
   }
 `

--- a/src/ViewLessonPage/ViewLessonLoader.js
+++ b/src/ViewLessonPage/ViewLessonLoader.js
@@ -21,11 +21,19 @@ export const ViewLessonLoader = ({ menuId }) => {
     variables: { id: menuId },
     skip: skipMenuQuery,
   })
+
+  const filteredMenu = menuData
+    ? menuData.menu.elements.filter((element) => element.lessonId === lessonId)
+    : null
+
+  const lessonIsFree = filteredMenu ? filteredMenu[0].freeLesson : null
+
   const menuIsPurchased =
     user && user.signedInUser.paidMenus.map((menu) => menu.id).includes(menuId)
+
   const userIsAdmin = user && user.signedInUser.type === 'admin'
 
-  const showLesson = userIsAdmin || menuIsPurchased
+  const showLesson = userIsAdmin || menuIsPurchased || lessonIsFree
 
   const lessonIsLoaded = data && data.lesson
 

--- a/src/ViewLessonPage/ViewLessonLoader.js
+++ b/src/ViewLessonPage/ViewLessonLoader.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { useQuery } from '@apollo/client'
 import { useParams } from 'react-router-dom'
 import { Spinner } from '_shared/Spinner'
@@ -6,8 +6,11 @@ import { LESSON_QUERY } from '_shared/LESSON_QUERY'
 import { MENU_QUERY } from './MENU_QUERY'
 import { Lesson } from './Lesson'
 import PropTypes from 'prop-types'
+import { CurrentUserContext } from '_shared/CurrentUserContextProvider'
 
 export const ViewLessonLoader = ({ menuId }) => {
+  const { user } = useContext(CurrentUserContext)
+
   let { lessonId } = useParams()
   const skipMenuQuery = !menuId ? true : false
   const { data, loading, error } = useQuery(LESSON_QUERY, {
@@ -18,6 +21,15 @@ export const ViewLessonLoader = ({ menuId }) => {
     variables: { id: menuId },
     skip: skipMenuQuery,
   })
+  const menuIsPurchased =
+    user && user.signedInUser.paidMenus.map((menu) => menu.id).includes(menuId)
+  const userIsAdmin = user && user.signedInUser.type === 'admin'
+
+  const showLesson = userIsAdmin || menuIsPurchased
+
+  const lessonIsLoaded = data && data.lesson
+
+  const lessonAvailable = showLesson && lessonIsLoaded
 
   if (error) {
     console.error(error)
@@ -28,7 +40,7 @@ export const ViewLessonLoader = ({ menuId }) => {
 
   return loading || menuLoading ? (
     <Spinner />
-  ) : data && data.lesson ? (
+  ) : lessonAvailable ? (
     <Lesson
       lesson={data.lesson}
       menuId={menuId}

--- a/src/_shared/SIGNED_USER_QUERY.js
+++ b/src/_shared/SIGNED_USER_QUERY.js
@@ -7,6 +7,9 @@ export const SIGNED_USER_QUERY = gql`
       login
       id
       type
+      paidMenus {
+        id
+      }
     }
   }
 `

--- a/src/lambda/dbData/db.js
+++ b/src/lambda/dbData/db.js
@@ -153,7 +153,7 @@ const addMenu = (id) => {
 
   return docClient.put(params).promise()
 }
-const addUser = (id, name, login, password, type, email) => {
+const addUser = (id, name, login, password, type, email, paidMenus) => {
   const docClient = new AWS.DynamoDB.DocumentClient()
   const params = {
     TransactItems: [
@@ -166,6 +166,7 @@ const addUser = (id, name, login, password, type, email) => {
             password: password,
             type: type,
             email: email,
+            paidMenus: paidMenus,
           },
           TableName: USER_TABLE_NAME,
           ConditionExpression: 'attribute_not_exists(id)',

--- a/src/lambda/graphql.js
+++ b/src/lambda/graphql.js
@@ -248,7 +248,8 @@ const resolvers = {
           args.input.login,
           hashPassword(args.input.password),
           args.input.type,
-          args.input.email
+          args.input.email,
+          args.input.paidMenus
         )
         .then(() => true)
         .catch(() => false)

--- a/src/lambda/graphql/typeDefs.js
+++ b/src/lambda/graphql/typeDefs.js
@@ -85,6 +85,7 @@ export default gql`
     type: String
     email: String
     expdate: Int
+    paidMenus: [Menu]
   }
 
   type AddLessonResponse {
@@ -193,12 +194,17 @@ export default gql`
     conclusionAudio: ConclusionAudioInput
   }
 
+  input PaidMenusInput {
+    id: ID!
+  }
+
   input AddUserInput {
     name: String
     login: String
     password: String
     type: String
     email: String
+    paidMenus: [PaidMenusInput]
   }
   input AddHashUserInput {
     login: String
@@ -235,6 +241,7 @@ export default gql`
     previousLogin: String
     email: String
     previousEmail: String
+    paidMenus: [PaidMenusInput]
   }
 
   type Query {

--- a/src/lambda/graphql/typeDefs.js
+++ b/src/lambda/graphql/typeDefs.js
@@ -66,6 +66,7 @@ export default gql`
   }
 
   type MenuElement {
+    freeLesson: Boolean!
     lessonId: String!
     lesson: Lesson!
   }
@@ -212,6 +213,7 @@ export default gql`
   }
 
   input ElementMenuInput {
+    freeLesson: Boolean
     initials: String
     lessonId: String
     image: String


### PR DESCRIPTION
This PR alters the `MenuElement` by adding the `freeLesson` boolean, meaning its necessary to readd the lessons on the menus (delete the lessons and add them again, as the addLesson method on the editMenuPage already adds the `freeLesson` boolean) or manually add `freeLesson` to the elements of each Menu on the database


First iteration of the paywall:

Added paidMenus to user

Menu page should now only be fully available to users with the respective menu id in their paidMenus or admin users.

Lesson page also only possible to be seen by admins, users that enter that lesson through the menu and have that paidMenu in their user info or in case the lesson is marked as free.

If the menu isnt purchased the page is going to display as this: 
- At the top are the free lessons
- In the middle is the paywall, which right now has placeholder text
- At the bottom paid lessons that are greyed out and are not possible to click nor access even if their respective url is used

![image](https://user-images.githubusercontent.com/70253649/116452052-a92c8e00-a833-11eb-91b2-38e6dc62f8c7.png)
