### PR TITLE
transition/layout

### DIFF
--- a/src/_shared/AudioButton/AudioButton.js
+++ b/src/_shared/AudioButton/AudioButton.js
@@ -20,6 +20,7 @@ export const AudioButton = ({
   color,
   playingColor,
   showDots,
+  hideButton,
 }) => {
   if (!color) color = colors.ready
   if (!playingColor) playingColor = colors.playing
@@ -82,7 +83,11 @@ export const AudioButton = ({
   const showDot = showDots && audioUrls[0]
 
   return (
-    <Wrapper onClick={playIfEnabled} disabled={disabled}>
+    <Wrapper
+      onClick={playIfEnabled}
+      disabled={disabled}
+      hideButton={hideButton}
+    >
       {showDot && (
         <DotWrapper>
           {[...Array(numOfDots)].map((n, i) => (
@@ -110,4 +115,5 @@ AudioButton.propTypes = {
   beforeTrailCount: PropTypes.number,
   afterTrailCount: PropTypes.number,
   showDots: PropTypes.bool,
+  hideButton: PropTypes.bool,
 }

--- a/src/_shared/AudioButton/Wrapper.js
+++ b/src/_shared/AudioButton/Wrapper.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 export const Wrapper = styled.div`
   cursor: ${({ disabled }) => (disabled ? null : 'pointer')};
-  display: flex;
+  display: ${({ hideButton }) => (hideButton ? 'none' : 'flex')};
   align-items: center;
   flex-direction: column;
 `

--- a/src/_shared/CheckFirstLetter/InnerWrapper.js
+++ b/src/_shared/CheckFirstLetter/InnerWrapper.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+export const InnerWrapper = styled.div`
+  width: 100px;
+  display: ${({ hide }) => (hide ? 'none' : 'flex')};
+  justify-content: center;
+`

--- a/src/_shared/CheckFirstLetter/Wrapper.js
+++ b/src/_shared/CheckFirstLetter/Wrapper.js
@@ -3,8 +3,7 @@ import styled from 'styled-components'
 export const Wrapper = styled.div`
   display: flex;
   width: 100%;
-  justify-content: space-around;
-  flex-direction: column;
+  justify-content: space-evenly;
   align-items: center;
   height: 250px;
 `

--- a/src/_shared/Icon/Icon.js
+++ b/src/_shared/Icon/Icon.js
@@ -1,10 +1,17 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 import { Play } from './svg/Play'
 import { Speaker } from './svg/Speaker'
 import { ThumbsDown } from './svg/ThumbsDown'
 import { ThumbsUp } from './svg/ThumbsUp'
+
+const Wrapper = styled.div`
+  display: inline-block;
+  transition: opacity 2s;
+  opacity: ${({ fadeOut }) => (fadeOut ? 0 : 1)};
+`
 
 const components = {
   Play: Play,
@@ -17,16 +24,24 @@ export const Icon = ({
   shape = 'Play',
   color = '#000',
   onClick,
+  fadeOut,
   size = 30,
 }) => {
+  const [startTransition, setStartTransition] = useState(false)
+  useEffect(() => {
+    if (fadeOut)
+      setTimeout(() => {
+        setStartTransition(true)
+      }, 1000)
+  }, [fadeOut])
   if (!components[shape]) {
     throw new Error(`component ${shape} is not supported`)
   }
   const IconSvg = React.createElement(components[shape], { color, size })
   return (
-    <div onClick={onClick} style={{ display: 'inline-block' }}>
+    <Wrapper fadeOut={startTransition} onClick={onClick}>
       {IconSvg}
-    </div>
+    </Wrapper>
   )
 }
 
@@ -35,4 +50,5 @@ Icon.propTypes = {
   onClick: PropTypes.func,
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  fadeOut: PropTypes.bool,
 }

--- a/src/_shared/YesOrNo/Wrapper.js
+++ b/src/_shared/YesOrNo/Wrapper.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 export const Wrapper = styled.div`
-  display: flex;
+  display: ${({ showYesOrNo }) => (showYesOrNo ? 'flex' : 'none')};
   width: 100px;
   justify-content: space-between;
 `

--- a/src/_shared/YesOrNo/YesOrNo.js
+++ b/src/_shared/YesOrNo/YesOrNo.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useEffect } from 'react'
 import { Wrapper } from './Wrapper'
 import PropTypes from 'prop-types'
 import loadable from '@loadable/component'
@@ -16,16 +16,9 @@ export const YesOrNo = ({
   urlWrongAnswerExplanation,
   onComplete,
   color,
+  showYesOrNo,
 }) => {
-  // const [_, setAnswer] = useState(null)
   const [alreadyAnswered, setAlreadyAnswered] = useState(false)
-  // const answerYes = useCallback(() => {
-  //   setAnswer('yes')
-  // }, [setAnswer])
-
-  // const answerNo = useCallback(() => {
-  //   setAnswer('no')
-  // }, [setAnswer])
 
   const yesaudioUrls = useMemo(
     () =>
@@ -48,13 +41,16 @@ export const YesOrNo = ({
     onComplete()
   }
 
+  useEffect(() => {
+    setAlreadyAnswered(false)
+  }, [urlRightAnswerExplanation, urlWrongAnswerExplanation])
+
   return (
-    <Wrapper>
+    <Wrapper showYesOrNo={showYesOrNo}>
       <AudioButton
         icon="ThumbsUp"
         disabled={alreadyAnswered}
         playingColor={correctAnswer === 'yes' ? colors.right : colors.wrong}
-        // onClick={answerYes}
         onComplete={onAnswer}
         color={color}
         audioUrls={yesaudioUrls}
@@ -63,7 +59,6 @@ export const YesOrNo = ({
         icon="ThumbsDown"
         disabled={alreadyAnswered}
         playingColor={correctAnswer === 'no' ? colors.right : colors.wrong}
-        // onClick={answerNo}
         onComplete={onAnswer}
         color={color}
         audioUrls={noaudioUrls}
@@ -78,4 +73,5 @@ YesOrNo.propTypes = {
   urlWrongAnswerExplanation: PropTypes.string,
   color: PropTypes.string,
   onComplete: PropTypes.string,
+  showYesOrNo: PropTypes.bool,
 }


### PR DESCRIPTION
On lesson page, checkFirstLetter element should now properly display how many audios are present above the second play button:

![image](https://user-images.githubusercontent.com/70253649/117491111-2481f400-af46-11eb-9857-b6219b28418d.png)

After first and second audio explaining, the respective `ThumbsUp` or `ThumbsDown` icon should take the play button position for 3 seconds, starting to fade out after 1 second and completely by the 3 second mark, at which point the play button returns with the updated collored dot:

![image](https://user-images.githubusercontent.com/70253649/117491321-6dd24380-af46-11eb-85b8-112aa5d8dbb4.png)

![image](https://user-images.githubusercontent.com/70253649/117491334-71fe6100-af46-11eb-874f-9d49cdd53236.png)


The `YesOrNo` buttons should no longer cause the other play button to move whenever they render:

![image](https://user-images.githubusercontent.com/70253649/117491414-91958980-af46-11eb-8a2d-5502216af4e3.png)


