### PR TITLE
item to item and imageUrl

### DIFF
--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Exercises/Exercises.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Exercises/Exercises.js
@@ -88,7 +88,6 @@ export const Exercises = ({ exercises, changeExercises, imageFilePrefix }) => {
         correctAnswer: ['p'],
       },
     ])
-  console.log('exercises', exercises)
 
   return (
     <>

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/InnerItem.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/InnerItem.js
@@ -1,72 +1,23 @@
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { TextAndInput } from '_shared/TextAndInput'
-import { FileUploader } from '_shared/FileUploader'
-import { DragAndDrop } from '_shared/DragAndDrop'
-import { FileDownloader } from '../../FileDownloader'
-import { LessonItem } from '_shared/LessonItem'
-import { InnerItemWrapper, NameWrapper, LessonItemWrapper } from './Item.styles'
+import { InnerItemWrapper, NameWrapper, Label } from './Item.styles'
 import { colors } from '_shared/colors'
 import { DeleteItemButton } from './DeleteItemButton'
-import styled from 'styled-components'
-export const UploaderWrapper = styled.div`
-  display: flex;
-  margin-left: -12px;
-`
-export const InnerItem = ({
-  imageFilePrefix,
-  updateItem,
-  changeItem,
-  deleteItem,
-  item,
-}) => {
-  const IsImage =
-    item.endsWith('.png') || item.endsWith('.svg') || item.endsWith('.jpg')
-  const [loading, setLoading] = useState(false)
-  const [showImage, setShowImage] = useState(true)
-  const displayImage = IsImage && showImage
 
-  const toggleImage = () => {
-    setShowImage(!showImage)
-  }
+export const InnerItem = ({ changeItem, deleteItem, item }) => {
   return (
-    <DragAndDrop imageFilePrefix={imageFilePrefix} updateItemUrl={updateItem}>
-      <InnerItemWrapper>
-        <UploaderWrapper>
-          <FileUploader
-            color={colors.grayText}
-            loading={loading}
-            setLoading={setLoading}
-            imageFilePrefix={imageFilePrefix}
-            updateItem={updateItem}
-          />
-        </UploaderWrapper>
-        {IsImage && <FileDownloader color={colors.grayText} filename={item} />}
-        {displayImage ? (
-          <LessonItemWrapper>
-            <LessonItem
-              image={item}
-              color={colors.grayText}
-              onClick={toggleImage}
-            />
-          </LessonItemWrapper>
-        ) : IsImage && !showImage ? (
-          <NameWrapper>
-            <TextAndInput onChange={changeItem} color={colors.dimmedPrimary} />
-          </NameWrapper>
-        ) : null}
-        {!IsImage && (
-          <NameWrapper>
-            <TextAndInput
-              value={item}
-              onChange={changeItem}
-              color={colors.dimmedPrimary}
-            />
-          </NameWrapper>
-        )}
-        <DeleteItemButton deleteItem={deleteItem} />
-      </InnerItemWrapper>
-    </DragAndDrop>
+    <InnerItemWrapper>
+      <NameWrapper>
+        <Label>Item:</Label>
+        <TextAndInput
+          value={item}
+          onChange={changeItem}
+          color={colors.dimmedPrimary}
+        />
+      </NameWrapper>
+      <DeleteItemButton deleteItem={deleteItem} />
+    </InnerItemWrapper>
   )
 }
 

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/Item.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/Item.js
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types'
 import { Wrapper, ItemWrapper } from './Item.styles'
 import { ItemAudio } from './ItemAudio'
 import { InnerItem } from './InnerItem'
+import { ItemImage } from './ItemImage'
 
 export const Item = ({
   imageFilePrefix,
   item,
-  url,
+  imageUrl,
+  audioUrl,
   updateItem,
   deleteItem,
   changeItem,
@@ -15,17 +17,20 @@ export const Item = ({
   return (
     <Wrapper>
       <ItemWrapper>
-        <ItemAudio
-          updateItem={updateItem}
-          url={url}
-          audioFilePrefix={imageFilePrefix}
-        />
         <InnerItem
-          imageFilePrefix={imageFilePrefix}
-          updateItem={updateItem}
           changeItem={changeItem}
           deleteItem={deleteItem}
           item={item}
+        />
+        <ItemImage
+          imageFilePrefix={imageFilePrefix}
+          updateItem={updateItem}
+          imageUrl={imageUrl}
+        />
+        <ItemAudio
+          updateItem={updateItem}
+          audioUrl={audioUrl}
+          audioFilePrefix={imageFilePrefix}
         />
       </ItemWrapper>
     </Wrapper>
@@ -34,8 +39,9 @@ export const Item = ({
 
 Item.propTypes = {
   imageFilePrefix: PropTypes.string,
-  url: PropTypes.string,
   item: PropTypes.string,
+  imageUrl: PropTypes.string,
+  audioUrl: PropTypes.string,
   updateItem: PropTypes.func,
   deleteItem: PropTypes.func,
   changeItem: PropTypes.func,

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/Item.styles.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/Item.styles.js
@@ -6,6 +6,11 @@ export const LessonItemWrapper = styled.div`
   padding-left: 8px;
 `
 
+export const UploaderWrapper = styled.div`
+  display: flex;
+  margin-left: -12px;
+`
+
 export const Wrapper = styled.div`
   min-height: 4rem;
   display: flex;
@@ -17,11 +22,10 @@ export const NameWrapper = styled.div`
   display: flex;
   align-self: center;
   width: 100%;
-  padding-left: 8px;
 `
 
 export const AudioButtonsWrapper = styled.div`
-  padding-top: 10px;
+  padding: 10px 0 10px 0;
   display: flex;
 `
 export const ItemWrapper = styled.div`
@@ -32,6 +36,8 @@ export const ItemWrapper = styled.div`
 export const InnerItemWrapper = styled.div`
   display: flex;
   padding-top: 10px;
-  padding-bottom: 10px;
   width: 100%;
+`
+export const Label = styled.label`
+  padding-right: 12px;
 `

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/ItemAudio.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/ItemAudio.js
@@ -7,14 +7,14 @@ import PropTypes from 'prop-types'
 import { FileDownloader } from '../../FileDownloader'
 import { colors } from '_shared/colors'
 
-export const ItemAudio = ({ audioFilePrefix, updateItem, url }) => {
+export const ItemAudio = ({ audioFilePrefix, updateItem, audioUrl }) => {
   const [loading, setLoading] = useState(false)
   return (
     <DragAndDrop audioFilePrefix={audioFilePrefix} updateItemUrl={updateItem}>
       <AudioButtonsWrapper>
         <AudioButton
           audioUrls={[
-            `https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${url}`,
+            `https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${audioUrl}`,
           ]}
           color={colors.grayText}
           size={20}
@@ -24,9 +24,9 @@ export const ItemAudio = ({ audioFilePrefix, updateItem, url }) => {
           loading={loading}
           setLoading={setLoading}
           audioFilePrefix={audioFilePrefix}
-          updateItemUrl={updateItem}
+          updateItemAudioUrl={updateItem}
         />
-        <FileDownloader color={colors.grayText} filename={url} />
+        <FileDownloader color={colors.grayText} filename={audioUrl} />
       </AudioButtonsWrapper>
     </DragAndDrop>
   )
@@ -34,6 +34,6 @@ export const ItemAudio = ({ audioFilePrefix, updateItem, url }) => {
 
 ItemAudio.propTypes = {
   audioFilePrefix: PropTypes.string,
-  url: PropTypes.string,
+  audioUrl: PropTypes.string,
   updateItem: PropTypes.func,
 }

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/ItemImage.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Item/ItemImage.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react'
+import { colors } from '_shared/colors'
+import { LessonItem } from '_shared/LessonItem'
+import { FileDownloader } from '../../FileDownloader'
+import { FileUploader } from '_shared/FileUploader'
+import { DragAndDrop } from '_shared/DragAndDrop'
+import { DeleteItemButton } from './DeleteItemButton'
+import PropTypes from 'prop-types'
+import { LessonItemWrapper, UploaderWrapper } from './Item.styles'
+
+export const ItemImage = ({ imageFilePrefix, updateItem, imageUrl }) => {
+  const [loading, setLoading] = useState(false)
+  const deleteImage = () => updateItem({ imageUrl: null })
+
+  return (
+    <>
+      <DragAndDrop
+        imageFilePrefix={imageFilePrefix}
+        updateItemImageUrl={updateItem}
+      >
+        <UploaderWrapper>
+          <FileUploader
+            color={colors.grayText}
+            loading={loading}
+            setLoading={setLoading}
+            imageFilePrefix={imageFilePrefix}
+            updateItemImageUrl={updateItem}
+          />
+        </UploaderWrapper>
+        <FileDownloader color={colors.grayText} filename={imageUrl} />
+        <DeleteItemButton deleteItem={deleteImage} />
+        <LessonItemWrapper>
+          <LessonItem image={imageUrl} color={colors.grayText} />
+        </LessonItemWrapper>
+      </DragAndDrop>
+    </>
+  )
+}
+
+ItemImage.propTypes = {
+  imageFilePrefix: PropTypes.string,
+  imageUrl: PropTypes.string,
+  updateItem: PropTypes.func,
+}

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Items.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Items/Items.js
@@ -29,12 +29,13 @@ const buildChangeItem = ({ items, itemIndex, changeItems }) => (item) => {
 }
 
 export const Items = ({ items, changeItems, imageFilePrefix }) => {
-  const addItem = () => changeItems([...items, { item: '', url: '' }])
+  const addItem = () =>
+    changeItems([...items, { item: '', imageUrl: '', audioUrl: '' }])
 
   return (
     <>
       {items &&
-        items.map(({ item, url }, itemIndex) => (
+        items.map(({ item, imageUrl, audioUrl }, itemIndex) => (
           <Item
             imageFilePrefix={imageFilePrefix}
             index={itemIndex}
@@ -50,7 +51,8 @@ export const Items = ({ items, changeItems, imageFilePrefix }) => {
             })}
             changeItem={buildChangeItem({ items, itemIndex, changeItems })}
             item={item}
-            url={url}
+            imageUrl={imageUrl}
+            audioUrl={audioUrl}
             key={itemIndex}
           />
         ))}

--- a/src/_shared/DragAndDrop.js
+++ b/src/_shared/DragAndDrop.js
@@ -72,8 +72,8 @@ export const DragAndDrop = ({
   updateWordAudio,
   updateRightAnswerAudio,
   updateWrongAnswerAudio,
-  updateItem,
-  updateItemUrl,
+  updateItemImageUrl,
+  updateItemAudioUrl,
   updateExerciseImageUrl,
   videoFilePrefix,
   imageFilePrefix,
@@ -126,8 +126,8 @@ export const DragAndDrop = ({
           })
         else if (setImageUrl) setImageUrl(filename)
         else if (setMenuImage) setMenuImage(filename)
-        else if (updateItem) updateItem({ item: filename })
-        else if (updateItemUrl) updateItemUrl({ url: filename })
+        else if (updateItemImageUrl) updateItemImageUrl({ imageUrl: filename })
+        else if (updateItemAudioUrl) updateItemAudioUrl({ audioUrl: filename })
         else if (updateExerciseImageUrl)
           updateExerciseImageUrl({ imageUrl: filename })
       }
@@ -152,11 +152,11 @@ export const DragAndDrop = ({
       updateWordAudio,
       updateRightAnswerAudio,
       updateWrongAnswerAudio,
-      updateItem,
+      updateItemImageUrl,
       imageFilePrefix,
       setImageUrl,
       setMenuImage,
-      updateItemUrl,
+      updateItemAudioUrl,
       updateExerciseImageUrl,
     ]
   )
@@ -237,7 +237,7 @@ DragAndDrop.propTypes = {
   audioFilePrefix: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   updateAudio: PropTypes.func,
-  updateItem: PropTypes.func,
+  updateItemImageUrl: PropTypes.func,
   setMenuImage: PropTypes.func,
   updateWordAudio: PropTypes.func,
   updateRightAnswerAudio: PropTypes.func,
@@ -246,6 +246,6 @@ DragAndDrop.propTypes = {
   updateVideo: PropTypes.func,
   imageFilePrefix: PropTypes.string,
   setImageUrl: PropTypes.func,
-  updateItemUrl: PropTypes.func,
+  updateItemAudioUrl: PropTypes.func,
   updateExerciseImageUrl: PropTypes.func,
 }

--- a/src/_shared/Element/addBucketPrefixesToElementParams.js
+++ b/src/_shared/Element/addBucketPrefixesToElementParams.js
@@ -13,7 +13,8 @@ const addBucketPrefixToWords = (words) =>
 const addBucketPrefixToItems = (items) =>
   items.map((item) => ({
     ...item,
-    url: addBucketPrefix(item.url),
+    imageUrl: addBucketPrefix(item.imageUrl),
+    audioUrl: addBucketPrefix(item.audioUrl),
   }))
 
 const addBucketPrefixToExercises = (exercises) =>

--- a/src/_shared/FileUploader.js
+++ b/src/_shared/FileUploader.js
@@ -57,8 +57,8 @@ export const FileUploader = ({
   updateRightAnswerAudio,
   updateWrongAnswerAudio,
   updateAudio,
-  updateItem,
-  updateItemUrl,
+  updateItemImageUrl,
+  updateItemAudioUrl,
   videoFilePrefix,
   imageFilePrefix,
   setImageUrl,
@@ -114,8 +114,8 @@ export const FileUploader = ({
           })
         else if (setImageUrl) setImageUrl(filename)
         else if (setMenuImage) setMenuImage(filename)
-        else if (updateItem) updateItem({ item: filename })
-        else if (updateItemUrl) updateItemUrl({ url: filename })
+        else if (updateItemImageUrl) updateItemImageUrl({ imageUrl: filename })
+        else if (updateItemAudioUrl) updateItemAudioUrl({ audioUrl: filename })
         else if (updateExerciseImageUrl)
           updateExerciseImageUrl({ imageUrl: filename })
       }
@@ -143,8 +143,8 @@ export const FileUploader = ({
       updateWrongAnswerAudio,
       setImageUrl,
       setMenuImage,
-      updateItem,
-      updateItemUrl,
+      updateItemImageUrl,
+      updateItemAudioUrl,
       updateExerciseImageUrl,
     ]
   )
@@ -177,7 +177,7 @@ FileUploader.propTypes = {
   inputBoxMessage: PropTypes.string,
   updateAudio: PropTypes.func,
   updateWordAudio: PropTypes.func,
-  updateItem: PropTypes.func,
+  updateItemImageUrl: PropTypes.func,
   updateRightAnswerAudio: PropTypes.func,
   updateWrongAnswerAudio: PropTypes.func,
   setMenuImage: PropTypes.func,
@@ -188,6 +188,6 @@ FileUploader.propTypes = {
   updateVideo: PropTypes.func,
   imageFilePrefix: PropTypes.string,
   setImageUrl: PropTypes.func,
-  updateItemUrl: PropTypes.func,
+  updateItemAudioUrl: PropTypes.func,
   updateExerciseImageUrl: PropTypes.func,
 }

--- a/src/_shared/ItemsAndAudiosElement/Items.js
+++ b/src/_shared/ItemsAndAudiosElement/Items.js
@@ -17,12 +17,7 @@ const Img = styled.img`
 `
 
 export const Items = ({ children }) => {
-  const IsImage =
-    children && children.item
-      ? children.item.endsWith('.png') ||
-        children.item.endsWith('.svg') ||
-        children.item.endsWith('.jpg')
-      : null
+  const IsImage = children && children.imageUrl
   const textRef = useRef()
   const [width, setWidth] = useState(null)
   useEffect(() => {
@@ -47,11 +42,7 @@ export const Items = ({ children }) => {
           </text>
         </svg>
       )}
-      {IsImage && (
-        <Img
-          src={`https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${children.item}`}
-        />
-      )}
+      {IsImage && <Img src={children.imageUrl} />}
     </Wrapper>
   )
 }

--- a/src/_shared/ItemsAndAudiosElement/ItemsAndAudiosElement.js
+++ b/src/_shared/ItemsAndAudiosElement/ItemsAndAudiosElement.js
@@ -98,7 +98,7 @@ export const ItemsAndAudiosElement = ({
             color={actual && !exerciseCompleted ? colors.actual : null}
             disabled={end}
             icon="Play"
-            audioUrls={items.map(({ url }) => url)}
+            audioUrls={items.map(({ audioUrl }) => audioUrl)}
             width={20}
             onStepStart={setInstructionsCompleted}
             onStepComplete={setListened}

--- a/src/_shared/LESSON_QUERY.js
+++ b/src/_shared/LESSON_QUERY.js
@@ -12,7 +12,8 @@ export const LESSON_QUERY = gql`
         letter
         items {
           item
-          url
+          imageUrl
+          audioUrl
         }
         exercises {
           word

--- a/src/lambda/graphql/getAllFilesFromLesson.js
+++ b/src/lambda/graphql/getAllFilesFromLesson.js
@@ -18,7 +18,7 @@ export const getAllFilesFromLesson = (lesson) => {
 
   const items = lesson.elements
     .map(({ items }) =>
-      items ? items.map(({ url, item }) => [url, item]) : null
+      items ? items.map(({ audioUrl, imageUrl }) => [audioUrl, imageUrl]) : null
     )
     .flat(2)
 

--- a/src/lambda/graphql/typeDefs.js
+++ b/src/lambda/graphql/typeDefs.js
@@ -38,7 +38,8 @@ export default gql`
 
   type Item {
     item: String
-    url: String
+    imageUrl: String
+    audioUrl: String
   }
 
   type Exercise {
@@ -184,9 +185,8 @@ export default gql`
 
   input ItemInput {
     item: String
-    url: String
-    correctAnswer: [String]
-    options: [String]
+    imageUrl: String
+    audioUrl: String
   }
 
   input ExercisesInput {


### PR DESCRIPTION
On edit lesson page:

To improve clarity on the element `itemsAndAudios` and to ease the reusability of `items` its composition went from
 `item {
 item
 url
}`

to

`item {
item
imageUrl
audioUrl
}`

Updated both the edit and view portion of the element to accommodate this change.