### PR TITLE
audio elements/video layout improvement

### DIFF
--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/AudioButtonWrappers.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/AudioButtonWrappers.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 export const AudioButtonWrapper = styled.div`
   display: inline-flex;
-
+  align-items: flex-start;
   @media (max-width: 375px) {
     display: none;
   }
@@ -10,6 +10,7 @@ export const AudioButtonWrapper = styled.div`
 
 export const AudioButtonMobileWrapper = styled.div`
   display: inline-flex;
+  align-items: flex-start;
   @media (min-width: 376px) {
     display: none;
   }

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Audios/Audio/AudioButtonWrapper.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Audios/Audio/AudioButtonWrapper.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 export const AudioButtonWrapper = styled.div`
   display: flex;
   color: #fff;
+  align-items: flex-start;
   @media (max-width: 375px) {
     display: none;
   }
@@ -9,6 +10,7 @@ export const AudioButtonWrapper = styled.div`
 export const AudioButtonMobileWrapper = styled.div`
   display: flex;
   color: #fff;
+  align-items: flex-start;
   @media (min-width: 376px) {
     display: none;
   }

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/ConclusionAudio/ConclusionAudio.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/ConclusionAudio/ConclusionAudio.js
@@ -59,13 +59,31 @@ export const ConclusionAudio = ({
 
   const addConclusionAudio = () => setShowConclusionAudio(true)
   const AudioButtonBuilder = (size) => (
-    <AudioButton
-      audioUrls={[
-        `https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${conclusionAudio.url}`,
-      ]}
-      size={size}
-      color={colors.grayText}
-    />
+    <>
+      <AudioButton
+        audioUrls={[
+          `https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${conclusionAudio.url}`,
+        ]}
+        size={size}
+        color={colors.grayText}
+      />
+      <FileUploader
+        color={colors.grayText}
+        audioFilePrefix={audioFilePrefix}
+        updateAudio={buildUpdateAudio({
+          conclusionAudio,
+          changeConclusionAudio,
+        })}
+        loading={loading}
+        setLoading={setLoading}
+      />
+      {checkUrl && (
+        <FileDownloader
+          color={colors.grayText}
+          filename={conclusionAudio.url}
+        />
+      )}
+    </>
   )
 
   return (
@@ -86,22 +104,7 @@ export const ConclusionAudio = ({
             <AudioButtonMobileWrapper>
               {AudioButtonBuilder(17)}
             </AudioButtonMobileWrapper>
-            <FileUploader
-              color={colors.grayText}
-              audioFilePrefix={audioFilePrefix}
-              updateAudio={buildUpdateAudio({
-                conclusionAudio,
-                changeConclusionAudio,
-              })}
-              loading={loading}
-              setLoading={setLoading}
-            />
-            {checkUrl && (
-              <FileDownloader
-                color={colors.grayText}
-                filename={conclusionAudio.url}
-              />
-            )}
+
             <ConclusionAudioNameWrapper>
               <TextAndInput
                 value={conclusionAudio.name}

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/ConclusionAudio/OptionalTextWrapper.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/ConclusionAudio/OptionalTextWrapper.js
@@ -3,4 +3,5 @@ import { colors } from '_shared/colors'
 
 export const OptionalTextWrapper = styled.div`
   color: ${colors.light};
+  padding-bottom: 5px;
 `

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/FileDownloader.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/FileDownloader.js
@@ -6,6 +6,7 @@ import { DownloadButton } from './DownloadButton'
 const Wrapper = styled.div`
   display: flex;
   align-items: center;
+  margin-top: -2px;
 `
 
 export const FileDownloader = ({ color, filename }) => {

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/InitialInstructions/InitialInstructions.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/InitialInstructions/InitialInstructions.js
@@ -59,13 +59,28 @@ export const InitialInstructions = ({
   const [loading, setLoading] = useState(false)
 
   const AudioButtonBuilder = (size) => (
-    <AudioButton
-      audioUrls={[
-        `https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${initialAudio.url}`,
-      ]}
-      size={size}
-      color={colors.grayText}
-    />
+    <>
+      <AudioButton
+        audioUrls={[
+          `https://${process.env.REACT_APP_MY_AWS_BUCKET_NAME}.s3-sa-east-1.amazonaws.com/${initialAudio.url}`,
+        ]}
+        size={size}
+        color={colors.grayText}
+      />
+      <FileUploader
+        color={colors.grayText}
+        audioFilePrefix={audioFilePrefix}
+        updateAudio={buildUpdateAudio({
+          initialAudio,
+          changeInitialAudio,
+        })}
+        loading={loading}
+        setLoading={setLoading}
+      />
+      {checkUrl && (
+        <FileDownloader color={colors.grayText} filename={initialAudio.url} />
+      )}
+    </>
   )
 
   return (
@@ -85,22 +100,7 @@ export const InitialInstructions = ({
             <AudioButtonMobileWrapper>
               {AudioButtonBuilder(17)}
             </AudioButtonMobileWrapper>
-            <FileUploader
-              color={colors.grayText}
-              audioFilePrefix={audioFilePrefix}
-              updateAudio={buildUpdateAudio({
-                initialAudio,
-                changeInitialAudio,
-              })}
-              loading={loading}
-              setLoading={setLoading}
-            />
-            {checkUrl && (
-              <FileDownloader
-                color={colors.grayText}
-                filename={initialAudio.url}
-              />
-            )}
+
             <InitialAudioNameWrapper>
               <TextAndInput
                 value={initialAudio.name}

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Videos/Video/UploadButtonWrapper.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Videos/Video/UploadButtonWrapper.js
@@ -1,10 +1,8 @@
 import styled from 'styled-components'
 
 export const UploadButtonWrapper = styled.div`
-  width: 50px;
   display: flex;
-  justify-content: center;
   align-items: flex-start;
-  align-self: center;
   cursor: pointer;
+  margin-left: -13px;
 `

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Videos/Video/Video.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Videos/Video/Video.js
@@ -22,6 +22,8 @@ export const Video = ({
   url,
 }) => {
   const [loading, setLoading] = useState(false)
+  const checkUrl = url && url !== ''
+
   return (
     <VideoWrapper>
       {loading ? (
@@ -40,7 +42,9 @@ export const Video = ({
                 loading={loading}
                 setLoading={setLoading}
               />
-              <FileDownloader color={colors.grayText} filename={url} />
+              {checkUrl && (
+                <FileDownloader color={colors.grayText} filename={url} />
+              )}
             </UploadButtonWrapper>
             <VideoFieldsWrapper>
               <VideoNameAndUrlWrapper>

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Videos/Video/Video.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Videos/Video/Video.js
@@ -9,6 +9,7 @@ import { DeleteVideoButton } from './DeleteVideoButton'
 import { TextAndInput } from '_shared/TextAndInput'
 import { FileUploader } from '_shared/FileUploader'
 import { DragAndDrop } from '_shared/DragAndDrop'
+import { FileDownloader } from '../../FileDownloader'
 import { colors } from '_shared/colors'
 import { Spinner } from '_shared/Spinner'
 
@@ -18,6 +19,7 @@ export const Video = ({
   updateVideo,
   deleteVideo,
   changeName,
+  url,
 }) => {
   const [loading, setLoading] = useState(false)
   return (
@@ -38,6 +40,7 @@ export const Video = ({
                 loading={loading}
                 setLoading={setLoading}
               />
+              <FileDownloader color={colors.grayText} filename={url} />
             </UploadButtonWrapper>
             <VideoFieldsWrapper>
               <VideoNameAndUrlWrapper>
@@ -65,4 +68,5 @@ Video.propTypes = {
   deleteVideo: PropTypes.func,
   index: PropTypes.number,
   changeName: PropTypes.func,
+  url: PropTypes.string,
 }

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Words/Word/RightAnswerRow.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Words/Word/RightAnswerRow.js
@@ -4,7 +4,11 @@ import { FileUploader } from '_shared/FileUploader'
 import { Spinner } from '_shared/Spinner'
 import { FileDownloader } from '../../FileDownloader'
 import { TextInput } from '../../TextInput'
-import { WordRightAnswerWrapper, WordAnswerInfoWrapper } from './Word.styles'
+import {
+  WordRightAnswerWrapper,
+  WordAnswerInfoWrapper,
+  ButtonsWrapper,
+} from './Word.styles'
 import { colors } from '_shared/colors'
 import PropTypes from 'prop-types'
 
@@ -27,20 +31,22 @@ export const RightAnswerRow = ({
           audioFilePrefix={audioFilePrefix}
           updateRightAnswerAudio={updateAudio}
         >
-          {audioButtonField(urlRightAnswerExplanation)}
-          <FileUploader
-            color={colors.grayText}
-            audioFilePrefix={audioFilePrefix}
-            updateRightAnswerAudio={updateAudio}
-            loading={rightAnswerLoading}
-            setLoading={setRightAnswerLoading}
-          />
-          {urlRightAnswerExplanation !== '' && (
-            <FileDownloader
+          <ButtonsWrapper>
+            {audioButtonField(urlRightAnswerExplanation)}
+            <FileUploader
               color={colors.grayText}
-              filename={urlRightAnswerExplanation}
+              audioFilePrefix={audioFilePrefix}
+              updateRightAnswerAudio={updateAudio}
+              loading={rightAnswerLoading}
+              setLoading={setRightAnswerLoading}
             />
-          )}
+            {urlRightAnswerExplanation !== '' && (
+              <FileDownloader
+                color={colors.grayText}
+                filename={urlRightAnswerExplanation}
+              />
+            )}
+          </ButtonsWrapper>
           <WordAnswerInfoWrapper>
             Acertou?
             <TextInput

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Words/Word/Word.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Words/Word/Word.js
@@ -11,7 +11,11 @@ import {
 } from '../../AudioButtonWrappers'
 import { AudioButton } from '_shared/AudioButton'
 import { colors } from '_shared/colors'
+import styled from 'styled-components'
 
+const Wrap = styled.div`
+  align-items: flex-start;
+`
 export const Word = ({
   audioFilePrefix,
   word,
@@ -28,7 +32,7 @@ export const Word = ({
   changeWrongAnswerExplanation,
 }) => {
   const AudioButtonField = (url) => (
-    <>
+    <Wrap>
       <AudioButtonWrapper>
         <AudioButton
           audioUrls={[
@@ -47,7 +51,7 @@ export const Word = ({
           color={colors.grayText}
         />
       </AudioButtonMobileWrapper>
-    </>
+    </Wrap>
   )
 
   return (

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Words/Word/Word.styles.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Words/Word/Word.styles.js
@@ -8,6 +8,11 @@ export const AnswerButtonsWrapper = styled.div`
   cursor: pointer;
 `
 
+export const ButtonsWrapper = styled.div`
+  display: flex;
+  align-items: flex-start;
+`
+
 export const AnswerChoiceWrapper = styled.div`
   color: ${colors.primary};
   cursor: pointer;
@@ -18,7 +23,7 @@ export const AnswerChoiceWrapper = styled.div`
 export const WordAndAnswerWrapper = styled.div`
   display: flex;
   justify-content: flex-start;
-  padding-top: 3px;
+  padding: 3px 0 10px 0;
   width: 100%;
 `
 
@@ -38,6 +43,7 @@ export const WordFieldsWrapper = styled.div`
 
 export const WordRightAnswerWrapper = styled.div`
   display: flex;
+  padding: 3px 0 10px 0;
 `
 
 export const WordWrapper = styled.div`

--- a/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Words/Word/WrongAnswerRow.js
+++ b/src/EditLessonPage/EditableLesson/EditableElements/EditableElement/Words/Word/WrongAnswerRow.js
@@ -4,7 +4,11 @@ import { FileUploader } from '_shared/FileUploader'
 import { Spinner } from '_shared/Spinner'
 import { FileDownloader } from '../../FileDownloader'
 import { TextInput } from '../../TextInput'
-import { WordWrongAnswerWrapper, WordAnswerInfoWrapper } from './Word.styles'
+import {
+  WordWrongAnswerWrapper,
+  WordAnswerInfoWrapper,
+  ButtonsWrapper,
+} from './Word.styles'
 import { colors } from '_shared/colors'
 import PropTypes from 'prop-types'
 
@@ -27,20 +31,22 @@ export const WrongAnswerRow = ({
           audioFilePrefix={audioFilePrefix}
           updateWrongAnswerAudio={updateAudio}
         >
-          {audioButtonField(urlWrongAnswerExplanation)}
-          <FileUploader
-            color={colors.grayText}
-            audioFilePrefix={audioFilePrefix}
-            updateWrongAnswerAudio={updateAudio}
-            loading={wrongAnswerLoading}
-            setLoading={setWrongAnswerLoading}
-          />
-          {urlWrongAnswerExplanation !== '' && (
-            <FileDownloader
+          <ButtonsWrapper>
+            {audioButtonField(urlWrongAnswerExplanation)}
+            <FileUploader
               color={colors.grayText}
-              filename={urlWrongAnswerExplanation}
+              audioFilePrefix={audioFilePrefix}
+              updateWrongAnswerAudio={updateAudio}
+              loading={wrongAnswerLoading}
+              setLoading={setWrongAnswerLoading}
             />
-          )}
+            {urlWrongAnswerExplanation !== '' && (
+              <FileDownloader
+                color={colors.grayText}
+                filename={urlWrongAnswerExplanation}
+              />
+            )}
+          </ButtonsWrapper>
           <WordAnswerInfoWrapper>
             Errou?
             <TextInput

--- a/src/_shared/CheckFirstLetter/CheckFirstLetter.js
+++ b/src/_shared/CheckFirstLetter/CheckFirstLetter.js
@@ -116,9 +116,15 @@ export const CheckFirstLetter = ({
         <YesOrNo
           showYesOrNo={showYesOrNo}
           color={actual && instructionsCompleted ? colors.actual : null}
-          correctAnswer={actualWord.startsWithTheLetter ? 'yes' : 'no'}
-          urlRightAnswerExplanation={actualWord.urlRightAnswerExplanation}
-          urlWrongAnswerExplanation={actualWord.urlWrongAnswerExplanation}
+          correctAnswer={
+            actualWord && actualWord.startsWithTheLetter ? 'yes' : 'no'
+          }
+          urlRightAnswerExplanation={
+            actualWord && actualWord.urlRightAnswerExplanation
+          }
+          urlWrongAnswerExplanation={
+            actualWord && actualWord.urlWrongAnswerExplanation
+          }
           onComplete={setAnswered}
         />
         <InnerWrapper hide={showYesOrNo}>


### PR DESCRIPTION
On edit lesson page, updated layout for the upload and download buttons of audios as to make them consistent with the play button:

Before in case the name of the audio/explanation of the audio was too big:

![image](https://user-images.githubusercontent.com/70253649/118022155-6b029480-b332-11eb-953a-c90e63c8d405.png)

After: 

![image](https://user-images.githubusercontent.com/70253649/118022229-81105500-b332-11eb-8d7a-60e652e5f243.png)


Added download button to videos